### PR TITLE
ci: Add GitHub Actions based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    # branches:
-    # - main
+    branches:
+    - main
   pull_request:
     branches:
     - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,6 @@ jobs:
     - name: Build library and examples on macOS
       if: matrix.os == 'macos-latest'
       run: |
-        ls -l /usr/local/Cellar/apache-arrow/*
-        echo "brew info apache-arrow"
-        brew info apache-arrow
-        echo "brew --prefix apache-arrow"
-        brew --prefix apache-arrow
         cmake \
           -DARROW_PATH=$(brew --prefix apache-arrow) \
           -S . \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         ls -l /usr/local/Cellar/apache-arrow/*
         cmake \
-          -DARROW_PATH=/usr/local/Cellar/apache-arrow/5.0.0 \
+          -DARROW_PATH=/usr/local/Cellar/apache-arrow \
           -S . \
           -B build
         cmake build -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
         apt-get update -y
         apt-get install -y \
           ca-certificates \
@@ -48,3 +47,12 @@ jobs:
         apt install -y \
           libarrow-dev \
           libparquet-dev
+
+    - name: Build library
+      run: |
+        cmake \
+          -DCMAKE_MODULE_PATH=$(find /usr/lib -type d -name arrow) \
+          -S . \
+          -B build
+        cmake build -L
+        cmake --build build --parallel $(($(nproc) - 1))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update -y
-        apt-get install -y \
+        sudo apt-get install -y \
           ca-certificates \
           lsb-release \
           wget \
@@ -42,9 +42,9 @@ jobs:
           pkg-config \
           cmake
         wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt install -y ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        apt update -y
-        apt install -y \
+        sudo apt-get install -y ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        sudo apt-get update -y
+        sudo apt-get install -y \
           libarrow-dev \
           libparquet-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        apt-get update -y
+        sudo apt-get update -y
         apt-get install -y \
           ca-certificates \
           lsb-release \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
     - name: Build library and examples on ${{ matrix.os }}
       if: matrix.os == 'macos-latest'
       run: |
-        find /usr/local/ -type d -name apache-arrow
+        ls -l /usr/local/Cellar/apache-arrow/*
         cmake \
-          -DARROW_PATH="$(find /usr/local/ -type d -name apache-arrow)/5.0.0" \
+          -DARROW_PATH=/usr/local/Cellar/apache-arrow/5.0.0 \
           -S . \
           -B build
         cmake build -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.9]
 
     steps:
@@ -52,11 +51,29 @@ jobs:
         # Install other tools
         sudo apt-get install -y tree
 
-    - name: Build library and examples
+    - name: Install build dependencies on ${{ matrix.os }}
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install apache-arrow
+        brew install tree
+
+    - name: Build library and examples on ${{ matrix.os }}
       if: matrix.os == 'ubuntu-latest'
       run: |
         cmake \
           -DCMAKE_MODULE_PATH=$(find /usr/lib -type d -name arrow) \
+          -S . \
+          -B build
+        cmake build -L
+        cmake --build build --parallel $(($(nproc) - 1))
+        tree build
+
+    - name: Build library and examples on ${{ matrix.os }}
+      if: matrix.os == 'macos-latest'
+      run: |
+        find /usr/local/ -type d -name apache-arrow
+        cmake \
+          -DARROW_PATH="$(find /usr/local/ -type d -name apache-arrow)/5.0.0" \
           -S . \
           -B build
         cmake build -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
     branches:
     - main
-  # Run daily at 1:02 UTC
+  # Run weekly at 1:02 Monday UTC
   schedule:
-  - cron:  '2 1 * * *'
+  - cron:  '2 1 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           libarrow-dev \
           libparquet-dev
 
+        # Install other tools
+        sudo apt-get install -y tree
+
     - name: Build library
       run: |
         cmake \
@@ -57,3 +60,4 @@ jobs:
           -B build
         cmake build -L
         cmake --build build --parallel $(($(nproc) - 1))
+        tree build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
         # Install other tools
         sudo apt-get install -y tree
 
-    - name: Build library
+    - name: Build library and examples
+      if: matrix.os == 'ubuntu-latest'
       run: |
         cmake \
           -DCMAKE_MODULE_PATH=$(find /usr/lib -type d -name arrow) \
@@ -61,3 +62,12 @@ jobs:
         cmake build -L
         cmake --build build --parallel $(($(nproc) - 1))
         tree build
+
+    - name: Run examples
+      run: |
+        pushd build/bin
+        ls -l
+        ./basic-example
+        ls -lhtra
+        ./struct-example
+        ls -lhtra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install build dependencies on ${{ matrix.os }}
+    - name: Install build dependencies on Ubuntu
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update -y
@@ -51,13 +51,13 @@ jobs:
         # Install other tools
         sudo apt-get install -y tree
 
-    - name: Install build dependencies on ${{ matrix.os }}
+    - name: Install build dependencies on macOS
       if: matrix.os == 'macos-latest'
       run: |
         brew install apache-arrow
         brew install tree
 
-    - name: Build library and examples on ${{ matrix.os }}
+    - name: Build library and examples on Ubuntu
       if: matrix.os == 'ubuntu-latest'
       run: |
         cmake \
@@ -68,7 +68,7 @@ jobs:
         cmake --build build --parallel $(($(nproc) - 1))
         tree build
 
-    - name: Build library and examples on ${{ matrix.os }}
+    - name: Build library and examples on macOS
       if: matrix.os == 'macos-latest'
       run: |
         ls -l /usr/local/Cellar/apache-arrow/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
         tree
         echo "Running struct-example"
         ./struct-example
-        tree
         popd
 
     - name: Install Python runtime dependencies
@@ -82,4 +81,4 @@ jobs:
 
     - name: Run metadata check
       run: |
-        python examples/python/dump-metadata.py example_dataset/example_dataset_0000.parquet
+        python examples/python/dump-metadata.py build/bin/example_dataset/example_dataset_0000.parquet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install build dependencies
+    - name: Install build dependencies on ${{ matrix.os }}
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,16 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         ls -l /usr/local/Cellar/apache-arrow/*
+        echo "brew info apache-arrow"
         brew info apache-arrow
+        echo "brew --prefix apache-arrow"
         brew --prefix apache-arrow
         cmake \
           -DARROW_PATH=$(brew --prefix apache-arrow) \
           -S . \
           -B build
         cmake build -L
-        cmake --build build --parallel $(($(nproc) - 1))
+        cmake --build build --parallel $(($(sysctl -n hw.logicalcpu) - 1))
         tree build
 
     - name: Run examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    # branches:
+    # - main
+  pull_request:
+    branches:
+    - main
+  # Run daily at 1:02 UTC
+  schedule:
+  - cron:  '2 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
+        python-version: [3.9]
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install build dependencies
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        apt-get update -y
+        apt-get install -y \
+          ca-certificates \
+          lsb-release \
+          wget \
+          build-essential \
+          pkg-config \
+          cmake
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt install -y ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        apt update -y
+        apt install -y \
+          libarrow-dev \
+          libparquet-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,19 @@ jobs:
       run: |
         pushd build/bin
         ls -l
+        echo "Running basic-example"
         ./basic-example
-        ls -lhtra
+        tree
+        echo "Running struct-example"
         ./struct-example
-        ls -lhtra
+        tree
+        popd
+
+    - name: Install Python runtime dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install "pyarrow>=4.0.0"
+
+    - name: Run metadata check
+      run: |
+        python examples/python/dump-metadata.py example_dataset/example_dataset_0000.parquet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         ls -l /usr/local/Cellar/apache-arrow/*
+        brew info apache-arrow
+        brew --prefix apache-arrow
         cmake \
-          -DARROW_PATH=/usr/local/Cellar/apache-arrow \
+          -DARROW_PATH=$(brew --prefix apache-arrow) \
           -S . \
           -B build
         cmake build -L


### PR DESCRIPTION
Resolves #5 

Add a GitHub Actions based CI for build tests. The GHA workflow runs across `ubuntu-latest` and `macos-latest` and uses OS checks to determine which dependencies and build approaches it needs to succeed. The built examples are also run as a spot check.

**Suggested squash and merge commit message**:
```
* Add GitHub Actions based CI build tests for the library and examples
   - Workflow runs on Linux and macOS
   - Workflow is triggered on pushes and PRs to main, on weekly CRON jobs, and on demand with workflow dispatch
```