### PR TITLE
Refactor and make fill types more robust

### DIFF
--- a/examples/cpp/basic_example.cpp
+++ b/examples/cpp/basic_example.cpp
@@ -125,6 +125,8 @@ int main(int argc, char* argv[]) {
 
     // create and initialize the parquetwriter::Writer
     namespace pw = parquetwriter;
+    pw::logging::set_debug(); // set debug for the examples
+
     pw::Writer writer;
     writer.set_layout(layout);
     writer.set_dataset_name("example_dataset");

--- a/examples/cpp/basic_example.cpp
+++ b/examples/cpp/basic_example.cpp
@@ -125,7 +125,7 @@ int main(int argc, char* argv[]) {
 
     // create and initialize the parquetwriter::Writer
     namespace pw = parquetwriter;
-    pw::logging::set_debug(); // set debug for the examples
+    pw::logging::set_debug();  // set debug for the examples
 
     pw::Writer writer;
     writer.set_layout(layout);

--- a/examples/cpp/struct_example.cpp
+++ b/examples/cpp/struct_example.cpp
@@ -104,6 +104,8 @@ int main(int argc, char* argv[]) {
 
     // create and initialize the parquetwriter::Writer
     namespace pw = parquetwriter;
+    pw::logging::set_debug(); // set debug for examples
+
     pw::Writer writer;
     writer.set_layout(layout);
     writer.set_dataset_name("example_dataset");

--- a/examples/cpp/struct_example.cpp
+++ b/examples/cpp/struct_example.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
 
     // create and initialize the parquetwriter::Writer
     namespace pw = parquetwriter;
-    pw::logging::set_debug(); // set debug for examples
+    pw::logging::set_debug();  // set debug for examples
 
     pw::Writer writer;
     writer.set_layout(layout);

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(parquet-writer
     PRIVATE
     parquet_writer.cpp
     parquet_helpers.cpp
+    parquet_writer_fill_types.cpp
     logging.cpp
 )
 

--- a/src/cpp/parquet_helpers.cpp
+++ b/src/cpp/parquet_helpers.cpp
@@ -7,16 +7,6 @@
 namespace parquetwriter {
 namespace helpers {
 
-ColumnWrapper::ColumnWrapper(std::string name)
-    : _name(name), _builder(nullptr) {}
-
-void ColumnWrapper::create_builder(std::shared_ptr<arrow::DataType> type) {
-    auto pool = arrow::default_memory_pool();
-    std::unique_ptr<arrow::ArrayBuilder> tmp;
-    WRITER_CHECK_RESULT(arrow::MakeBuilder(pool, type, &tmp));
-    _builder = tmp.release();
-}
-
 std::shared_ptr<arrow::DataType> datatype_from_string(
     const std::string& type_string) {
     std::shared_ptr<arrow::DataType> out_type = nullptr;
@@ -79,7 +69,7 @@ std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
                             throw std::runtime_error(err.str());
                         } else if (value_type3 == "struct") {
                             auto struct_fields =
-                                fields_from_json(jcontains3, field_name);
+                                columns_from_json(jcontains3, field_name);
                             auto end_list_type = arrow::struct_(struct_fields);
                             fields.push_back(arrow::field(
                                 field_name, arrow::list(arrow::list(
@@ -92,7 +82,7 @@ std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
                         }
                     } else if (value_type2 == "struct") {
                         auto struct_fields =
-                            fields_from_json(jcontains2, field_name);
+                            columns_from_json(jcontains2, field_name);
                         auto end_list_type = arrow::struct_(struct_fields);
                         fields.push_back(arrow::field(
                             field_name,
@@ -105,7 +95,7 @@ std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
                     }
                 } else if (value_type == "struct") {
                     auto struct_fields =
-                        fields_from_json(jcontains, field_name);
+                        columns_from_json(jcontains, field_name);
                     auto end_list_type = arrow::struct_(struct_fields);
                     fields.push_back(
                         arrow::field(field_name, arrow::list(end_list_type)));
@@ -116,7 +106,7 @@ std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
                 }
             }  // list
             else if (field_type == "struct") {
-                auto struct_fields = fields_from_json(jfield, field_name);
+                auto struct_fields = columns_from_json(jfield, field_name);
                 fields.push_back(
                     arrow::field(field_name, arrow::struct_(struct_fields)));
             } else {
@@ -128,120 +118,10 @@ std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
     return fields;
 }
 
-std::map<std::string, arrow::ArrayBuilder*> makeVariableMap(
-    std::shared_ptr<ColumnWrapper> node) {
-    auto builder = node->builder();
-    std::map<std::string, arrow::ArrayBuilder*> out_map;
-    makeVariableMap(builder, node->name(), "", out_map);
-    return out_map;
-}
-
-void makeVariableMap(arrow::ArrayBuilder* builder, std::string parentname,
-                     std::string prefix,
-                     std::map<std::string, arrow::ArrayBuilder*>& out_map) {
-    auto type = builder->type();
-    //if (builder->num_children() > 0) {
-    if (type->id() == arrow::Type::STRUCT) {
-        std::string struct_builder_name = parentname;  // + "/";
-        out_map[struct_builder_name] = builder;
-        for (size_t ichild = 0; ichild < builder->num_children(); ichild++) {
-            auto field = type->field(ichild);
-            auto child_builder = builder->child_builder(ichild).get();
-            auto child_type = child_builder->type();
-            auto n_child_children = child_builder->num_children();
-            bool child_is_nested = (child_builder->num_children() > 0);
-            bool child_is_list = (child_type->id() == arrow::Type::LIST);
-            if (child_is_nested) {
-                std::string this_name =
-                    parentname + "." + field->name();  // + "/";
-                out_map[this_name] = child_builder;
-
-                std::string child_name = parentname + "." + field->name();
-                makeVariableMap(child_builder, child_name, field->name(),
-                                out_map);
-            } else if (child_is_list) {
-                arrow::ListBuilder* list_builder =
-                    static_cast<arrow::ListBuilder*>(child_builder);
-                auto item_builder = list_builder->value_builder();
-                std::string outname = parentname + "." + field->name();
-                std::string list_name = outname;  // + "/list";
-                std::string val_name = outname + "/item";
-                out_map[list_name] = child_builder;
-                out_map[val_name] =
-                    item_builder;  // dynamic_cast<arrow::ArrayBuilder*>(item_builder);
-
-                //if(item_builder->type()->id() == arrow::Type::LIST) {
-                //    auto item2_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
-                //    std::string val2_name = val_name + "/item";
-                //    out_map[val2_name] = item2_builder;
-
-                //    if(item2_builder->type()->id() == arrow::Type::LIST) {
-                //        auto item3_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
-                //        std::string val3_name = val_name + "/item";
-                //        out_map[val3_name] = item3_builder;
-                //    }
-                //}
-            } else {
-                std::string outname = parentname + "." + field->name();
-                out_map[outname] = child_builder;
-            }
-        }  // ichild
-    } else if (type->id() == arrow::Type::LIST) {
-        auto list_builder = dynamic_cast<arrow::ListBuilder*>(builder);
-        std::string outname = parentname;
-        if (prefix != "") {
-            outname = prefix + "." + outname;
-        }
-        std::string list_name = outname;  // + "/list";
-        out_map[list_name] = list_builder;
-        std::string val_name = outname + "/item";
-        auto item_builder = list_builder->value_builder();
-        out_map[val_name] = item_builder;
-
-        //if(item_builder->type()->id() == arrow::Type::LIST) {
-        //    auto item2_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
-        //    std::string val2_name = val_name + "/item";
-        //    out_map[val2_name] = item2_builder;
-
-        //    if(item2_builder->type()->id() == arrow::Type::LIST) {
-        //        auto item3_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
-        //        std::string val3_name = val2_name + "/item";
-        //        out_map[val3_name] = item3_builder;
-        //    }
-        //}
-    } else {
-        std::string outname = parentname;
-        if (prefix != "") {
-            outname = prefix + "." + outname;
-        }
-        out_map[outname] = builder;
-    }
-}
-
-std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>
-col_builder_map_from_fields(
-    const std::vector<std::shared_ptr<arrow::Field>>& fields) {
-    std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>> out;
-    for (auto field : fields) {
-        auto field_name = field->name();
-        auto field_type = field->type();
-        auto node = std::make_shared<ColumnWrapper>(field_name);
-        node->create_builder(field_type);
-        out[field_name] = makeVariableMap(node);
-
-        auto log = logging::get_logger();
-        log->debug("{0} - ============= {1} MAP ===========",
-                   __PRETTYFUNCTION__, field_name);
-        for (const auto& [key, val] : makeVariableMap(node)) {
-            log->debug("{0} - key = {1}, val type = {2}", __PRETTYFUNCTION__,
-                       key, val->type()->name());
-        }
-    }
-    return out;
-}
-
-std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>
+std::pair<std::vector<std::string>, std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>>
 fill_field_builder_map_from_columns(const std::vector<std::shared_ptr<arrow::Field>>& columns) {
+
+    auto log = logging::get_logger();
 
     //
     // we want to create an entry for each column and then
@@ -250,6 +130,7 @@ fill_field_builder_map_from_columns(const std::vector<std::shared_ptr<arrow::Fie
     //
 
     std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>> out;
+    std::vector<std::string> field_names;
 
     for( auto column : columns ) {
         auto column_name = column->name();
@@ -270,134 +151,229 @@ fill_field_builder_map_from_columns(const std::vector<std::shared_ptr<arrow::Fie
         // add the parent builder -- this is all that is needed for a column
         // that is filling only FillTypes::VALUE
         column_builders[column_name] = column_builder;
+        field_names.push_back(column_name);
 
 
         // keep track of the fill type for this column
         //parquetwriter::FillType fill_type = parquetwriter::FillType::VALUE;
 
-        parquetwriter::FillType column_fill_type = fill_type_from_column(column_builder);
+        parquetwriter::FillType column_fill_type = column_filltype_from_builder(column_builder, column_name);
 
         if(column_fill_type == parquetwriter::FillType::INVALID) {
             throw std::runtime_error("Bad column \"" + column_name + "\"");
         }
+
+        // get the names of any sub-struct typed fields of structures
+        if(column_fill_type == parquetwriter::FillType::STRUCT) {
+            auto [names, struct_type_builders] = struct_type_field_builders(column_builder, column_name);
+            for(size_t i = 0; i < struct_type_builders.size(); i++) {
+                std::stringstream sub_name;
+                sub_name << column_name << "." << names.at(i);
+                column_builders[sub_name.str()] = struct_type_builders.at(i);
+                field_names.push_back(sub_name.str());
+            }
+        }
+
+        out[column_name] = column_builders;
     } // column iterator
+    return std::make_pair(field_names, out);
 }
 
-parquetwriter::FillType fill_type_from_column(arrow::ArrayBuilder* column_builder) {
+parquetwriter::struct_t struct_from_data_buffer_element(const parquetwriter::types::buffer_t& data, const std::string& field_name) {
+    struct_t struct_data;
+    try {
+        struct_data = std::get<struct_t>(data);
+    } catch(std::exception& e) {
+        std::stringstream err;
+        err << "Unable to parse struct field data for field \"" << field_name << "\"";
+        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::runtime_error("Invalid data shape");
+    }
+    return struct_data;
+}
 
-    parquetwriter::FillType fill_type = parquetwriter::FillType::INVALID;
+std::pair<std::vector<std::string>, std::vector<arrow::ArrayBuilder*>> 
+struct_type_field_builders(arrow::ArrayBuilder* builder, const std::string& column_name) {
+    if(builder->type()->id() != arrow::Type::STRUCT) {
+        std::stringstream err;
+        err << "Provided builder (name = \"" << column_name << "\") is not of STRUCT type, has type \"" << builder->type()->name() << "\"";
+        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::logic_error("Invalid builder type");
+    }
+    auto struct_builder = dynamic_cast<arrow::StructBuilder*>(builder);
 
-    std::string column_name = column_builder->name();
+    std::vector<arrow::ArrayBuilder*> out;
+    std::vector<std::string> names;
+    unsigned n_fields = struct_builder->num_children();
+    for(size_t ifield = 0; ifield < n_fields; ifield++) {
+        auto field_builder = struct_builder->child_builder(ifield).get();
+        auto field_type = field_builder->type();
+        std::string field_name = struct_builder->type()->field(ifield)->name();
+        bool is_list = field_type->id() == arrow::Type::LIST;
+        bool is_struct = field_type->id() == arrow::Type::STRUCT;
+
+        if(is_list) {
+            // check if struct_list
+            auto list_builder = dynamic_cast<arrow::ListBuilder*>(field_builder);
+            auto [depth, terminal_builder] = list_builder_description(list_builder);
+            if(terminal_builder->type()->id() == arrow::Type::STRUCT) {
+                names.push_back(field_name);
+                out.push_back(field_builder);
+            }
+        } else
+        if(is_struct) {
+            names.push_back(field_name);
+            out.push_back(field_builder);
+        }
+    } // ifield
+    return std::make_pair(names, out);
+}
+
+std::pair<unsigned, arrow::ArrayBuilder*> list_builder_description(
+        arrow::ListBuilder* builder) {
+
+    unsigned depth = 1;
+    auto list_builder = builder;
+    auto value_builder = list_builder->value_builder();
+
+    size_t unpack_count = 0;
+    while(value_builder->type()->id() == arrow::Type::LIST) {
+        if(unpack_count >= 3) break;
+        depth++;
+        list_builder = dynamic_cast<arrow::ListBuilder*>(value_builder);
+        value_builder = list_builder->value_builder();
+        unpack_count++;
+    }
+    return std::make_pair(depth, value_builder);
+}
+
+parquetwriter::FillType column_filltype_from_builder(arrow::ArrayBuilder* column_builder, const std::string& column_name) {
+
+    auto log = logging::get_logger();
+    //std::string column_name = column_builder->name();
 
     //
     // if there are any nested data structures, get the associated builders
     // 
-    bool is_list1d = column_builder->type()->id() == arrow::Type::LIST;
+    bool is_list = column_builder->type()->id() == arrow::Type::LIST;
     bool is_struct = column_builder->type()->id() == arrow::Type::STRUCT;
 
     // For FillTypes::VALUE_LIST_{1D,2D,3D} we do not need entries
     // for the value_builders since they can always be inferred from the
     // top level
 
-    if (is_list1d) {
-        auto value_builder = dynamic_cast<ListBuilder*>(column_builder);
-        bool is_list2d = value_builder->type()->id() == arrow::Type::LIST;
-        if(is_list2d) {
-            value_builder = dynamic_cast<ListBuilder*>(value_builder)->value_builder();
-            bool is_list3d = value_builder->type()->id() == arrow::Type::LIST;
-            if(is_list3d) {
-                //
-                // 3D list
-                //
+    if (is_list) {
 
-                // we do not support more than 3D list, so if this builder
-                // is of type list then throw an exception
-                value_builder = dynamic_cast<ListBuilder*>(value_builder)->value_builder();
-                bool is_list4d = value_builder->type()->id() == arrow::Type::LIST;
-                if(is_list4d) {
-                    std::stringstream err;
-                    err << "List depth >3 not supported, bad column \"" << column_name << "\"";
-                    log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                    throw std::runtime_error(err.str());
-                } // is_list4d
+        auto list_builder = dynamic_cast<arrow::ListBuilder*>(column_builder);
+        auto [depth, terminal_builder] = list_builder_description(list_builder);
 
-                // check if struct_list
-                bool is_struct_list3d = value_builder->type()->id() == arrow::Type::STRUCT;
-                if(is_struct_list3d) {
-                    auto struct_builder = dynamic_cast<arrow::StructBuilder*>(value_builder);
-                    bool valid_struct = validate_sub_struct_layout(struct_builder, column_name);
-                    if(!valid_struct) {
-                        throw std::runtime_error("Invalid layout for column \"" + column_name + "\"");
-                    }
-                    fill_type = parquetwriter::FillType::STRUCT_LIST_3D;
-                } else {
-                    fill_type = parquetwriter::FillType::VALUE_LIST_3D;
-                }
-            } // is_list3d
-            else {
-                //
-                // 2D list
-                //
+        if(terminal_builder->type()->id() == arrow::Type::LIST) {
+            std::stringstream err;
+            err << "List depth >3 not supported, bad column \"" << column_name << "\"";
+            logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+            return parquetwriter::FillType::INVALID;
+        }
 
-                // check if struct_list
-                bool is_struct_list2d = value_builder->type()->id() == arrow::Type::STRUCT;
-                if(is_struct_list2d) {
-                    auto struct_builder = dynamic_cast<arrow::StructBuilder*>(value_builder);
-                    bool valid_struct = validate_sub_struct_layout(struct_builder, column_name);
-                    if(!valid_struct) {
-                        throw std::runtime_error("Invalid layout for column \"" + column_name + "\"");
-                    }
-                    fill_type = parquetwriter::FillType::STRUCT_LIST_2D;
-                } else {
-                    fill_type = parquetwriter::FillType::VALUE_LIST_2D;
-                }
+        //
+        // either a struct_list or value_list 
+        //
+        if(terminal_builder->type()->id() == arrow::Type::STRUCT) {
+            // enforce that the structs contained in a struct_list column
+            // do not have fields that are themselves structs or struct-lists
+            auto struct_builder = dynamic_cast<arrow::StructBuilder*>(terminal_builder);
+            if(!struct_builder) {
+                std::stringstream err;
+                err << "FillType for STRUCT_LIST did not have terminal builder of type STRUCT";
+                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                throw std::logic_error("Bad column");
+            }
+            if(!valid_sub_struct_layout(struct_builder, column_name)) {
+                std::stringstream err;
+                err << "Invalid layout for column \"" << column_name << "\"";
+                logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                return parquetwriter::FillType::INVALID;
             }
 
-        } // is_list2d
-        else {
+            switch(depth) {
+                case 1 :
+                    return parquetwriter::FillType::STRUCT_LIST_1D;
+                    break;
+                case 2 :
+                    return parquetwriter::FillType::STRUCT_LIST_2D;
+                    break;
+                case 3 :
+                    return parquetwriter::FillType::STRUCT_LIST_3D;
+                    break;
+                default :
+                    return parquetwriter::FillType::INVALID;
+                    break;
+            } // switch
+        } else {
 
-            //
-            // 1D list
-            //
-
-            // check if struct_list
-            bool is_struct_list1d = value_builder->type()->id() == arrow::Type::STRUCT;
-            if(is_struct_list1d) {
-                auto struct_builder = dynamic_cast<arrow::StructBuilder*>(value_builder);
-                bool valid_struct = validate_sub_struct_layout(struct_builder, column_name);
-                if(!valid_struct) {
-                    throw std::runtime_error("Invalid layout for column \"" + column_name + "\"");
-                }
-                fill_type = parquetwriter::FillType::STRUCT_LIST_1D;
-            } else {
-                // list of values
-                fill_type = parquetwriter::FillType::VALUE_LIST_1D;
-            }
-        } // !is_list2d
-    } // is_list1d
-    else if(is_struct) {
-
+            switch(depth) {
+                case 1 :
+                    return parquetwriter::FillType::VALUE_LIST_1D;
+                    break;
+                case 2 :
+                    return parquetwriter::FillType::VALUE_LIST_2D;
+                    break;
+                case 3 :
+                    return parquetwriter::FillType::VALUE_LIST_3D;
+                    break;
+                default :
+                    return parquetwriter::FillType::INVALID;
+                    break;
+            } // switch
+        }
+    } else
+    if (is_struct) {
         auto struct_builder = dynamic_cast<arrow::StructBuilder*>(column_builder);
         unsigned number_of_fields = struct_builder->num_children();
         for(size_t ichild = 0; ichild < number_of_fields; ichild++) {
-            auto child = struct_builder->child_builder(ichild).get();
-            if(child->type()->id() == arrow::Type::STRUCT) {
+            auto child_builder = struct_builder->child_builder(ichild).get();
+            std::string field_name = struct_builder->type()->field(ichild)->name();
+            if(child_builder->type()->id() == arrow::Type::STRUCT) {
                 // no sub-structs that have fields of type struct
-            } else if(child->type()->id() == arrow::Type::LIST) {
+                auto sub_struct_builder = dynamic_cast<arrow::StructBuilder*>(child_builder);
+                if(!valid_sub_struct_layout(sub_struct_builder, column_name)) {
+                    std::stringstream err;
+                    err << "Invalid layout for column \"" << column_name  << "\"";
+                    logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                    return parquetwriter::FillType::INVALID;
+                }
+            } else if(child_builder->type()->id() == arrow::Type::LIST) {
                 // no sub-struct-lists
+                auto sub_list_builder = dynamic_cast<arrow::ListBuilder*>(child_builder);
+                auto [sub_list_depth, sub_list_terminal_builder] = list_builder_description(sub_list_builder);
+
+                // check dimension
+                if(sub_list_terminal_builder->type()->id() == arrow::Type::LIST) {
+                    std::stringstream err;
+                    err << "List depth >3 not supported for list field \"" << field_name << "\" of struct column \"" << column_name << "\"";
+                    logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                    return parquetwriter::FillType::INVALID;
+                } else
+                if(sub_list_terminal_builder->type()->id() == arrow::Type::STRUCT) {
+                    // check that sub-structs are "flat"
+                    auto sub_struct_builder = dynamic_cast<arrow::StructBuilder*>(sub_list_terminal_builder);
+                    if(!valid_sub_struct_layout(sub_struct_builder, column_name)) {
+                        std::stringstream err;
+                        err << "Invalid layout for field \"" << field_name << "\" of struct column \"" << column_name << "\"";
+                        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                        return parquetwriter::FillType::INVALID;
+                    }
+                }
             }
-        } // ichild
-        fill_type = parquetwriter::FillType::STRUCT;
-    } else {
-
-        fill_type = parquetwriter::FillType::VALUE;
-    }
-
-    return fill_type;
+        }
+        return parquetwriter::FillType::STRUCT;
+    } // is_struct
+    return parquetwriter::FillType::VALUE;
 }
 
-bool validate_sub_struct_layout(arrow::StructBuilder* struct_builder
+bool valid_sub_struct_layout(arrow::StructBuilder* struct_builder,
         const std::string& parent_column_name) {
+
+    auto log = logging::get_logger();
 
     //
     // any struct type that is itself a child field of some nested type
@@ -407,7 +383,7 @@ bool validate_sub_struct_layout(arrow::StructBuilder* struct_builder
     unsigned total_number_of_fields = struct_builder->num_children();
     for(size_t ichild = 0; ichild < total_number_of_fields; ichild++) {
         auto child_field_builder = struct_builder->child_builder(ichild).get();
-        auto child_field_name = child_field_builder->name();
+        auto child_field_name = struct_builder->type()->field(ichild)->name();
 
         //
         // no sub struct allowed
@@ -418,7 +394,7 @@ bool validate_sub_struct_layout(arrow::StructBuilder* struct_builder
             //
             std::stringstream err;
             err << "Child struct of column \"" << parent_column_name << "\" has invalid field \"" << child_field_name << "\" with type \"struct\"";
-            log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+            logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
             return false;
         } // is_struct
         else if(child_field_builder->type()->id() == arrow::Type::LIST) {
@@ -440,7 +416,7 @@ bool validate_sub_struct_layout(arrow::StructBuilder* struct_builder
             if(value_builder->type()->id() == arrow::Type::STRUCT) {
                 std::stringstream err;
                 err << "Child struct of column \"" << parent_column_name << "\"  has invalid field \"" << child_field_name << "\" with type \"struct list\"";
-                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
                 return false;
             }
         } // is_list

--- a/src/cpp/parquet_helpers.cpp
+++ b/src/cpp/parquet_helpers.cpp
@@ -118,9 +118,10 @@ std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
     return fields;
 }
 
-std::pair<std::vector<std::string>, std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>>
-fill_field_builder_map_from_columns(const std::vector<std::shared_ptr<arrow::Field>>& columns) {
-
+std::pair<std::vector<std::string>,
+          std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>>
+fill_field_builder_map_from_columns(
+    const std::vector<std::shared_ptr<arrow::Field>>& columns) {
     auto log = logging::get_logger();
 
     //
@@ -132,7 +133,7 @@ fill_field_builder_map_from_columns(const std::vector<std::shared_ptr<arrow::Fie
     std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>> out;
     std::vector<std::string> field_names;
 
-    for( auto column : columns ) {
+    for (auto column : columns) {
         auto column_name = column->name();
         auto column_type = column->type();
 
@@ -153,20 +154,21 @@ fill_field_builder_map_from_columns(const std::vector<std::shared_ptr<arrow::Fie
         column_builders[column_name] = column_builder;
         field_names.push_back(column_name);
 
-
         // keep track of the fill type for this column
-        //parquetwriter::FillType fill_type = parquetwriter::FillType::VALUE;
+        // parquetwriter::FillType fill_type = parquetwriter::FillType::VALUE;
 
-        parquetwriter::FillType column_fill_type = column_filltype_from_builder(column_builder, column_name);
+        parquetwriter::FillType column_fill_type =
+            column_filltype_from_builder(column_builder, column_name);
 
-        if(column_fill_type == parquetwriter::FillType::INVALID) {
+        if (column_fill_type == parquetwriter::FillType::INVALID) {
             throw std::runtime_error("Bad column \"" + column_name + "\"");
         }
 
         // get the names of any sub-struct typed fields of structures
-        if(column_fill_type == parquetwriter::FillType::STRUCT) {
-            auto [names, struct_type_builders] = struct_type_field_builders(column_builder, column_name);
-            for(size_t i = 0; i < struct_type_builders.size(); i++) {
+        if (column_fill_type == parquetwriter::FillType::STRUCT) {
+            auto [names, struct_type_builders] =
+                struct_type_field_builders(column_builder, column_name);
+            for (size_t i = 0; i < struct_type_builders.size(); i++) {
                 std::stringstream sub_name;
                 sub_name << column_name << "." << names.at(i);
                 column_builders[sub_name.str()] = struct_type_builders.at(i);
@@ -175,29 +177,36 @@ fill_field_builder_map_from_columns(const std::vector<std::shared_ptr<arrow::Fie
         }
 
         out[column_name] = column_builders;
-    } // column iterator
+    }  // column iterator
     return std::make_pair(field_names, out);
 }
 
-parquetwriter::struct_t struct_from_data_buffer_element(const parquetwriter::types::buffer_t& data, const std::string& field_name) {
+parquetwriter::struct_t struct_from_data_buffer_element(
+    const parquetwriter::types::buffer_t& data, const std::string& field_name) {
     struct_t struct_data;
     try {
         struct_data = std::get<struct_t>(data);
-    } catch(std::exception& e) {
+    } catch (std::exception& e) {
         std::stringstream err;
-        err << "Unable to parse struct field data for field \"" << field_name << "\"";
-        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        err << "Unable to parse struct field data for field \"" << field_name
+            << "\"";
+        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__,
+                                     err.str());
         throw std::runtime_error("Invalid data shape");
     }
     return struct_data;
 }
 
-std::pair<std::vector<std::string>, std::vector<arrow::ArrayBuilder*>> 
-struct_type_field_builders(arrow::ArrayBuilder* builder, const std::string& column_name) {
-    if(builder->type()->id() != arrow::Type::STRUCT) {
+std::pair<std::vector<std::string>, std::vector<arrow::ArrayBuilder*>>
+struct_type_field_builders(arrow::ArrayBuilder* builder,
+                           const std::string& column_name) {
+    if (builder->type()->id() != arrow::Type::STRUCT) {
         std::stringstream err;
-        err << "Provided builder (name = \"" << column_name << "\") is not of STRUCT type, has type \"" << builder->type()->name() << "\"";
-        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        err << "Provided builder (name = \"" << column_name
+            << "\") is not of STRUCT type, has type \""
+            << builder->type()->name() << "\"";
+        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__,
+                                     err.str());
         throw std::logic_error("Invalid builder type");
     }
     auto struct_builder = dynamic_cast<arrow::StructBuilder*>(builder);
@@ -205,40 +214,40 @@ struct_type_field_builders(arrow::ArrayBuilder* builder, const std::string& colu
     std::vector<arrow::ArrayBuilder*> out;
     std::vector<std::string> names;
     unsigned n_fields = struct_builder->num_children();
-    for(size_t ifield = 0; ifield < n_fields; ifield++) {
+    for (size_t ifield = 0; ifield < n_fields; ifield++) {
         auto field_builder = struct_builder->child_builder(ifield).get();
         auto field_type = field_builder->type();
         std::string field_name = struct_builder->type()->field(ifield)->name();
         bool is_list = field_type->id() == arrow::Type::LIST;
         bool is_struct = field_type->id() == arrow::Type::STRUCT;
 
-        if(is_list) {
+        if (is_list) {
             // check if struct_list
-            auto list_builder = dynamic_cast<arrow::ListBuilder*>(field_builder);
-            auto [depth, terminal_builder] = list_builder_description(list_builder);
-            if(terminal_builder->type()->id() == arrow::Type::STRUCT) {
+            auto list_builder =
+                dynamic_cast<arrow::ListBuilder*>(field_builder);
+            auto [depth, terminal_builder] =
+                list_builder_description(list_builder);
+            if (terminal_builder->type()->id() == arrow::Type::STRUCT) {
                 names.push_back(field_name);
                 out.push_back(field_builder);
             }
-        } else
-        if(is_struct) {
+        } else if (is_struct) {
             names.push_back(field_name);
             out.push_back(field_builder);
         }
-    } // ifield
+    }  // ifield
     return std::make_pair(names, out);
 }
 
 std::pair<unsigned, arrow::ArrayBuilder*> list_builder_description(
-        arrow::ListBuilder* builder) {
-
+    arrow::ListBuilder* builder) {
     unsigned depth = 1;
     auto list_builder = builder;
     auto value_builder = list_builder->value_builder();
 
     size_t unpack_count = 0;
-    while(value_builder->type()->id() == arrow::Type::LIST) {
-        if(unpack_count >= 3) break;
+    while (value_builder->type()->id() == arrow::Type::LIST) {
+        if (unpack_count >= 3) break;
         depth++;
         list_builder = dynamic_cast<arrow::ListBuilder*>(value_builder);
         value_builder = list_builder->value_builder();
@@ -247,14 +256,14 @@ std::pair<unsigned, arrow::ArrayBuilder*> list_builder_description(
     return std::make_pair(depth, value_builder);
 }
 
-parquetwriter::FillType column_filltype_from_builder(arrow::ArrayBuilder* column_builder, const std::string& column_name) {
-
+parquetwriter::FillType column_filltype_from_builder(
+    arrow::ArrayBuilder* column_builder, const std::string& column_name) {
     auto log = logging::get_logger();
-    //std::string column_name = column_builder->name();
+    // std::string column_name = column_builder->name();
 
     //
     // if there are any nested data structures, get the associated builders
-    // 
+    //
     bool is_list = column_builder->type()->id() == arrow::Type::LIST;
     bool is_struct = column_builder->type()->id() == arrow::Type::STRUCT;
 
@@ -263,116 +272,133 @@ parquetwriter::FillType column_filltype_from_builder(arrow::ArrayBuilder* column
     // top level
 
     if (is_list) {
-
         auto list_builder = dynamic_cast<arrow::ListBuilder*>(column_builder);
         auto [depth, terminal_builder] = list_builder_description(list_builder);
 
-        if(terminal_builder->type()->id() == arrow::Type::LIST) {
+        if (terminal_builder->type()->id() == arrow::Type::LIST) {
             std::stringstream err;
-            err << "List depth >3 not supported, bad column \"" << column_name << "\"";
-            logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+            err << "List depth >3 not supported, bad column \"" << column_name
+                << "\"";
+            logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__,
+                                         err.str());
             return parquetwriter::FillType::INVALID;
         }
 
         //
-        // either a struct_list or value_list 
+        // either a struct_list or value_list
         //
-        if(terminal_builder->type()->id() == arrow::Type::STRUCT) {
+        if (terminal_builder->type()->id() == arrow::Type::STRUCT) {
             // enforce that the structs contained in a struct_list column
             // do not have fields that are themselves structs or struct-lists
-            auto struct_builder = dynamic_cast<arrow::StructBuilder*>(terminal_builder);
-            if(!struct_builder) {
+            auto struct_builder =
+                dynamic_cast<arrow::StructBuilder*>(terminal_builder);
+            if (!struct_builder) {
                 std::stringstream err;
-                err << "FillType for STRUCT_LIST did not have terminal builder of type STRUCT";
+                err << "FillType for STRUCT_LIST did not have terminal builder "
+                       "of type STRUCT";
                 log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
                 throw std::logic_error("Bad column");
             }
-            if(!valid_sub_struct_layout(struct_builder, column_name)) {
+            if (!valid_sub_struct_layout(struct_builder, column_name)) {
                 std::stringstream err;
                 err << "Invalid layout for column \"" << column_name << "\"";
-                logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__,
+                                             err.str());
                 return parquetwriter::FillType::INVALID;
             }
 
-            switch(depth) {
-                case 1 :
+            switch (depth) {
+                case 1:
                     return parquetwriter::FillType::STRUCT_LIST_1D;
                     break;
-                case 2 :
+                case 2:
                     return parquetwriter::FillType::STRUCT_LIST_2D;
                     break;
-                case 3 :
+                case 3:
                     return parquetwriter::FillType::STRUCT_LIST_3D;
                     break;
-                default :
+                default:
                     return parquetwriter::FillType::INVALID;
                     break;
-            } // switch
+            }  // switch
         } else {
-
-            switch(depth) {
-                case 1 :
+            switch (depth) {
+                case 1:
                     return parquetwriter::FillType::VALUE_LIST_1D;
                     break;
-                case 2 :
+                case 2:
                     return parquetwriter::FillType::VALUE_LIST_2D;
                     break;
-                case 3 :
+                case 3:
                     return parquetwriter::FillType::VALUE_LIST_3D;
                     break;
-                default :
+                default:
                     return parquetwriter::FillType::INVALID;
                     break;
-            } // switch
+            }  // switch
         }
-    } else
-    if (is_struct) {
-        auto struct_builder = dynamic_cast<arrow::StructBuilder*>(column_builder);
+    } else if (is_struct) {
+        auto struct_builder =
+            dynamic_cast<arrow::StructBuilder*>(column_builder);
         unsigned number_of_fields = struct_builder->num_children();
-        for(size_t ichild = 0; ichild < number_of_fields; ichild++) {
+        for (size_t ichild = 0; ichild < number_of_fields; ichild++) {
             auto child_builder = struct_builder->child_builder(ichild).get();
-            std::string field_name = struct_builder->type()->field(ichild)->name();
-            if(child_builder->type()->id() == arrow::Type::STRUCT) {
+            std::string field_name =
+                struct_builder->type()->field(ichild)->name();
+            if (child_builder->type()->id() == arrow::Type::STRUCT) {
                 // no sub-structs that have fields of type struct
-                auto sub_struct_builder = dynamic_cast<arrow::StructBuilder*>(child_builder);
-                if(!valid_sub_struct_layout(sub_struct_builder, column_name)) {
+                auto sub_struct_builder =
+                    dynamic_cast<arrow::StructBuilder*>(child_builder);
+                if (!valid_sub_struct_layout(sub_struct_builder, column_name)) {
                     std::stringstream err;
-                    err << "Invalid layout for column \"" << column_name  << "\"";
-                    logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                    err << "Invalid layout for column \"" << column_name
+                        << "\"";
+                    logging::get_logger()->error("{0} - {1}",
+                                                 __PRETTYFUNCTION__, err.str());
                     return parquetwriter::FillType::INVALID;
                 }
-            } else if(child_builder->type()->id() == arrow::Type::LIST) {
+            } else if (child_builder->type()->id() == arrow::Type::LIST) {
                 // no sub-struct-lists
-                auto sub_list_builder = dynamic_cast<arrow::ListBuilder*>(child_builder);
-                auto [sub_list_depth, sub_list_terminal_builder] = list_builder_description(sub_list_builder);
+                auto sub_list_builder =
+                    dynamic_cast<arrow::ListBuilder*>(child_builder);
+                auto [sub_list_depth, sub_list_terminal_builder] =
+                    list_builder_description(sub_list_builder);
 
                 // check dimension
-                if(sub_list_terminal_builder->type()->id() == arrow::Type::LIST) {
+                if (sub_list_terminal_builder->type()->id() ==
+                    arrow::Type::LIST) {
                     std::stringstream err;
-                    err << "List depth >3 not supported for list field \"" << field_name << "\" of struct column \"" << column_name << "\"";
-                    logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                    err << "List depth >3 not supported for list field \""
+                        << field_name << "\" of struct column \"" << column_name
+                        << "\"";
+                    logging::get_logger()->error("{0} - {1}",
+                                                 __PRETTYFUNCTION__, err.str());
                     return parquetwriter::FillType::INVALID;
-                } else
-                if(sub_list_terminal_builder->type()->id() == arrow::Type::STRUCT) {
+                } else if (sub_list_terminal_builder->type()->id() ==
+                           arrow::Type::STRUCT) {
                     // check that sub-structs are "flat"
-                    auto sub_struct_builder = dynamic_cast<arrow::StructBuilder*>(sub_list_terminal_builder);
-                    if(!valid_sub_struct_layout(sub_struct_builder, column_name)) {
+                    auto sub_struct_builder =
+                        dynamic_cast<arrow::StructBuilder*>(
+                            sub_list_terminal_builder);
+                    if (!valid_sub_struct_layout(sub_struct_builder,
+                                                 column_name)) {
                         std::stringstream err;
-                        err << "Invalid layout for field \"" << field_name << "\" of struct column \"" << column_name << "\"";
-                        logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                        err << "Invalid layout for field \"" << field_name
+                            << "\" of struct column \"" << column_name << "\"";
+                        logging::get_logger()->error(
+                            "{0} - {1}", __PRETTYFUNCTION__, err.str());
                         return parquetwriter::FillType::INVALID;
                     }
                 }
             }
         }
         return parquetwriter::FillType::STRUCT;
-    } // is_struct
+    }  // is_struct
     return parquetwriter::FillType::VALUE;
 }
 
 bool valid_sub_struct_layout(arrow::StructBuilder* struct_builder,
-        const std::string& parent_column_name) {
-
+                             const std::string& parent_column_name) {
     auto log = logging::get_logger();
 
     //
@@ -381,46 +407,52 @@ bool valid_sub_struct_layout(arrow::StructBuilder* struct_builder,
     // struct lists and structs are not allowd
     //
     unsigned total_number_of_fields = struct_builder->num_children();
-    for(size_t ichild = 0; ichild < total_number_of_fields; ichild++) {
+    for (size_t ichild = 0; ichild < total_number_of_fields; ichild++) {
         auto child_field_builder = struct_builder->child_builder(ichild).get();
         auto child_field_name = struct_builder->type()->field(ichild)->name();
 
         //
         // no sub struct allowed
         //
-        if(child_field_builder->type()->id() == arrow::Type::STRUCT) {
+        if (child_field_builder->type()->id() == arrow::Type::STRUCT) {
             //
             // disallow a field if it itself is a struct
             //
             std::stringstream err;
-            err << "Child struct of column \"" << parent_column_name << "\" has invalid field \"" << child_field_name << "\" with type \"struct\"";
-            logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+            err << "Child struct of column \"" << parent_column_name
+                << "\" has invalid field \"" << child_field_name
+                << "\" with type \"struct\"";
+            logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__,
+                                         err.str());
             return false;
-        } // is_struct
-        else if(child_field_builder->type()->id() == arrow::Type::LIST) {
-
+        }  // is_struct
+        else if (child_field_builder->type()->id() == arrow::Type::LIST) {
             //
             // disallow a field if it itself is a struct list
             //
 
             size_t unpack_count = 0;
-            auto list_builder = dynamic_cast<arrow::ListBuilder*>(child_field_builder);
+            auto list_builder =
+                dynamic_cast<arrow::ListBuilder*>(child_field_builder);
             auto value_builder = list_builder->value_builder();
             while (value_builder->type()->id() == arrow::Type::LIST) {
-                if(unpack_count >= 3) break;
+                if (unpack_count >= 3) break;
                 list_builder = dynamic_cast<arrow::ListBuilder*>(value_builder);
                 value_builder = list_builder->value_builder();
                 unpack_count++;
             }
 
-            if(value_builder->type()->id() == arrow::Type::STRUCT) {
+            if (value_builder->type()->id() == arrow::Type::STRUCT) {
                 std::stringstream err;
-                err << "Child struct of column \"" << parent_column_name << "\"  has invalid field \"" << child_field_name << "\" with type \"struct list\"";
-                logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                err << "Child struct of column \"" << parent_column_name
+                    << "\"  has invalid field \"" << child_field_name
+                    << "\" with type \"struct list\"";
+                logging::get_logger()->error("{0} - {1}", __PRETTYFUNCTION__,
+                                             err.str());
                 return false;
             }
-        } // is_list
-    } // ichild
+        }  // is_list
+    }      // ichild
 
     return true;
 }

--- a/src/cpp/parquet_helpers.cpp
+++ b/src/cpp/parquet_helpers.cpp
@@ -140,7 +140,8 @@ void makeVariableMap(arrow::ArrayBuilder* builder, std::string parentname,
                      std::string prefix,
                      std::map<std::string, arrow::ArrayBuilder*>& out_map) {
     auto type = builder->type();
-    if (builder->num_children() > 0) {
+    //if (builder->num_children() > 0) {
+    if (type->id() == arrow::Type::STRUCT) {
         std::string struct_builder_name = parentname;  // + "/";
         out_map[struct_builder_name] = builder;
         for (size_t ichild = 0; ichild < builder->num_children(); ichild++) {
@@ -168,6 +169,18 @@ void makeVariableMap(arrow::ArrayBuilder* builder, std::string parentname,
                 out_map[list_name] = child_builder;
                 out_map[val_name] =
                     item_builder;  // dynamic_cast<arrow::ArrayBuilder*>(item_builder);
+
+                //if(item_builder->type()->id() == arrow::Type::LIST) {
+                //    auto item2_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
+                //    std::string val2_name = val_name + "/item";
+                //    out_map[val2_name] = item2_builder;
+
+                //    if(item2_builder->type()->id() == arrow::Type::LIST) {
+                //        auto item3_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
+                //        std::string val3_name = val_name + "/item";
+                //        out_map[val3_name] = item3_builder;
+                //    }
+                //}
             } else {
                 std::string outname = parentname + "." + field->name();
                 out_map[outname] = child_builder;
@@ -182,7 +195,20 @@ void makeVariableMap(arrow::ArrayBuilder* builder, std::string parentname,
         std::string list_name = outname;  // + "/list";
         out_map[list_name] = list_builder;
         std::string val_name = outname + "/item";
-        out_map[val_name] = list_builder->value_builder();
+        auto item_builder = list_builder->value_builder();
+        out_map[val_name] = item_builder;
+
+        //if(item_builder->type()->id() == arrow::Type::LIST) {
+        //    auto item2_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
+        //    std::string val2_name = val_name + "/item";
+        //    out_map[val2_name] = item2_builder;
+
+        //    if(item2_builder->type()->id() == arrow::Type::LIST) {
+        //        auto item3_builder = dynamic_cast<arrow::ListBuilder*>(item_builder)->value_builder();
+        //        std::string val3_name = val2_name + "/item";
+        //        out_map[val3_name] = item3_builder;
+        //    }
+        //}
     } else {
         std::string outname = parentname;
         if (prefix != "") {

--- a/src/cpp/parquet_helpers.cpp
+++ b/src/cpp/parquet_helpers.cpp
@@ -382,6 +382,9 @@ parquetwriter::FillType fill_type_from_column(arrow::ArrayBuilder* column_builde
         for(size_t ichild = 0; ichild < number_of_fields; ichild++) {
             auto child = struct_builder->child_builder(ichild).get();
             if(child->type()->id() == arrow::Type::STRUCT) {
+                // no sub-structs that have fields of type struct
+            } else if(child->type()->id() == arrow::Type::LIST) {
+                // no sub-struct-lists
             }
         } // ichild
         fill_type = parquetwriter::FillType::STRUCT;

--- a/src/cpp/parquet_helpers.h
+++ b/src/cpp/parquet_helpers.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "parquet_writer_fill_types.h"
+
 #include <iostream>
 // std/stl
 #include <map>
@@ -127,12 +129,20 @@ class ColumnWrapper {
 
 std::shared_ptr<arrow::DataType> datatype_from_string(
     const std::string& type_string);
-std::vector<std::shared_ptr<arrow::Field>> fields_from_json(
+std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
     const json& jlayout, const std::string& current_node = "");
 
 std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>
 col_builder_map_from_fields(
     const std::vector<std::shared_ptr<arrow::Field>>& fields);
+
+std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>
+fill_field_builder_map_from_columns(
+        const std::vector<std::shared_ptr<arrow::Field>>& columns);
+
+parquetwriter::FillType fill_type_from_column_builder(arrow::ArrayBuilder* column_builder);
+
+bool validate_sub_struct_layout(arrow::StructBuilder* struct_builder, const std::string& parent_column_name);
 
 std::map<std::string, arrow::ArrayBuilder*> makeVariableMap(
     std::shared_ptr<ColumnWrapper> node);

--- a/src/cpp/parquet_helpers.h
+++ b/src/cpp/parquet_helpers.h
@@ -34,10 +34,10 @@
     if constexpr (std::is_same<TEMPLATE_TYPE, CPP_CLASS>::value) {           \
         auto vb = dynamic_cast<arrow::TYPE_CLASS##Builder*>(                 \
             LIST_BUILDER->value_builder());                                  \
-        for(size_t i = 0; i < val.size(); i++) { \
-            PARQUET_THROW_NOT_OK(LIST_BUILDER->Append()); \
-            PARQUET_THROW_NOT_OK(vb->AppendValues(val.at(i))); \
-        } \
+        for (size_t i = 0; i < val.size(); i++) {                            \
+            PARQUET_THROW_NOT_OK(LIST_BUILDER->Append());                    \
+            PARQUET_THROW_NOT_OK(vb->AppendValues(val.at(i)));               \
+        }                                                                    \
     } else
 
 // macro for filling 3d lists (vector<vector<vector<...>>>)
@@ -103,18 +103,23 @@ std::vector<std::shared_ptr<arrow::Field>> columns_from_json(
     const json& jlayout, const std::string& current_node = "");
 
 std::pair<std::vector<std::string>,
-std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>>
+          std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>>
 fill_field_builder_map_from_columns(
-        const std::vector<std::shared_ptr<arrow::Field>>& columns);
+    const std::vector<std::shared_ptr<arrow::Field>>& columns);
 
-parquetwriter::FillType column_filltype_from_builder(arrow::ArrayBuilder* column_builder, const std::string& column_name);
+parquetwriter::FillType column_filltype_from_builder(
+    arrow::ArrayBuilder* column_builder, const std::string& column_name);
 
-bool valid_sub_struct_layout(arrow::StructBuilder* struct_builder, const std::string& parent_column_name);
-std::pair<unsigned, arrow::ArrayBuilder*> list_builder_description(arrow::ListBuilder* list_builder);
-std::pair<std::vector<std::string>, std::vector<arrow::ArrayBuilder*>> 
-struct_type_field_builders(arrow::ArrayBuilder* builder, const std::string& column_name);
+bool valid_sub_struct_layout(arrow::StructBuilder* struct_builder,
+                             const std::string& parent_column_name);
+std::pair<unsigned, arrow::ArrayBuilder*> list_builder_description(
+    arrow::ListBuilder* list_builder);
+std::pair<std::vector<std::string>, std::vector<arrow::ArrayBuilder*>>
+struct_type_field_builders(arrow::ArrayBuilder* builder,
+                           const std::string& column_name);
 
-parquetwriter::struct_t struct_from_data_buffer_element(const parquetwriter::types::buffer_t& data, const std::string& field_name);
+parquetwriter::struct_t struct_from_data_buffer_element(
+    const parquetwriter::types::buffer_t& data, const std::string& field_name);
 
 std::pair<unsigned, unsigned> field_nums_from_struct(
     const arrow::StructBuilder* builder, const std::string& column_name);

--- a/src/cpp/parquet_writer.cpp
+++ b/src/cpp/parquet_writer.cpp
@@ -90,7 +90,7 @@ void Writer::set_layout(const std::string& field_layout_json_str) {
 void Writer::set_layout(const nlohmann::json& field_layout) {
     // there must be a top-level "fields" node
 
-    _columns = helpers::fields_from_json(field_layout);
+    _columns = helpers::columns_from_json(field_layout);
     if (_columns.size() == 0) {
         std::stringstream err;
         err << "No fields constructed from provided file layout";
@@ -99,6 +99,14 @@ void Writer::set_layout(const nlohmann::json& field_layout) {
         throw std::runtime_error(err.str());
     }
 
+    // debug print-out
+    log->debug("{0} - {1} columns loaded from provided layout:", __PRETTYFUNCTION__, _columns.size());
+    auto n_columns = _columns.size();
+    for(size_t icolumn = 0; icolumn < n_columns; icolumn++) {
+        std::string column_name = _columns.at(icolumn)->name();
+        log->devug("{0} -     [{1}/{2}] {3}", __PRETTYFUNCTION__, icolumn+1, n_columns, column_name);
+    } // icolumn
+
     _schema = arrow::schema(_columns);
     _arrays.clear();
     if (!_file_metadata.empty()) {
@@ -106,6 +114,8 @@ void Writer::set_layout(const nlohmann::json& field_layout) {
     }
     // create the column -> ArrayBuilder mapping
     _col_builder_map = helpers::col_builder_map_from_fields(_columns);
+
+    auto fill_field_builder_map = helpers::fill_field_builder_map_from_columns(_columns);
 
     _expected_fields_to_fill.clear();
 

--- a/src/cpp/parquet_writer.cpp
+++ b/src/cpp/parquet_writer.cpp
@@ -1,6 +1,5 @@
 #include "parquet_writer.h"
 
-#include "logging.h"
 #include "parquet_helpers.h"
 
 // std/stl
@@ -99,69 +98,38 @@ void Writer::set_layout(const nlohmann::json& field_layout) {
         throw std::runtime_error(err.str());
     }
 
-    // debug print-out
-    log->debug("{0} - {1} columns loaded from provided layout:", __PRETTYFUNCTION__, _columns.size());
-    auto n_columns = _columns.size();
-    for(size_t icolumn = 0; icolumn < n_columns; icolumn++) {
-        std::string column_name = _columns.at(icolumn)->name();
-        log->devug("{0} -     [{1}/{2}] {3}", __PRETTYFUNCTION__, icolumn+1, n_columns, column_name);
-    } // icolumn
-
     _schema = arrow::schema(_columns);
     _arrays.clear();
     if (!_file_metadata.empty()) {
         this->set_metadata(_file_metadata);
     }
     // create the column -> ArrayBuilder mapping
-    _col_builder_map = helpers::col_builder_map_from_fields(_columns);
 
-    auto fill_field_builder_map = helpers::fill_field_builder_map_from_columns(_columns);
+    auto [expected_fields_to_fill, column_builder_map] = helpers::fill_field_builder_map_from_columns(_columns);
+    _expected_fields_to_fill = expected_fields_to_fill;
+    _column_builder_map = column_builder_map;
 
-    _expected_fields_to_fill.clear();
+    _expected_fields_filltype_map.clear();
 
-    log->error("{0} - COL build map size = {1}", __PRETTYFUNCTION__, _col_builder_map.size());
-    size_t total_n_to_call_fill_on = 0;
-    for(const auto& [col_name, builder_map] : _col_builder_map) {
+    log->debug("{0} - ============================================", __PRETTYFUNCTION__);
+    log->debug("{0} - Loaded fill_field_builder_map (size = {1}):", __PRETTYFUNCTION__, _column_builder_map.size());
+    size_t total_fills_per_row = 0;
+    size_t icolumn = 0;
+    for(const auto& column : _columns) {
+        std::string col_name = column->name();
+        auto col_builder_map = _column_builder_map.at(col_name);
+        log->debug("{0} - Column #{1}: {2}", __PRETTYFUNCTION__, icolumn++, col_name);
+        for(const auto& [sub_name, sub_builder] : col_builder_map) {
+            log->debug("{0} -      {1}: type = {2}, fill_type = {3}", __PRETTYFUNCTION__, sub_name, sub_builder->type()->name(), filltype_to_string(helpers::column_filltype_from_builder(sub_builder, sub_name)));
+            total_fills_per_row++;
 
-        log->error("{0} - COLUMN {1} has {2} sub-builders:", __PRETTYFUNCTION__, col_name, builder_map.size());
-        for(const auto& [sub_name, sub_builder] : builder_map) {
-            log->error("{0} -   --> sub_builder = {1}", __PRETTYFUNCTION__, sub_name);
-            if(sub_name.find("/item") != std::string::npos) continue; // don't consider list value_builder
-            if(sub_name == col_name) {
-                log->error("            ====> SUB_NAME++ = {0}", sub_name);
-                total_n_to_call_fill_on++;
-                _expected_fields_to_fill.push_back(sub_name);
-            } else
-            if(sub_builder->type()->id() == arrow::Type::LIST) {
-                auto value_builder = dynamic_cast<arrow::ListBuilder*>(sub_builder)->value_builder();
-
-                size_t try_count = 0;
-                while(value_builder->type()->id() == arrow::Type::LIST) {
-                    if(try_count >= 3) break;
-                    auto list_builder = dynamic_cast<arrow::ListBuilder*>(value_builder);
-                    value_builder = list_builder->value_builder();
-                    try_count++;
-
-                }
-                if(value_builder->type()->id() == arrow::Type::STRUCT) {
-                    total_n_to_call_fill_on++;
-                    _expected_fields_to_fill.push_back(sub_name);
-                    log->error("            ====> SUB_NAME++ = {0}", sub_name);
-                }
-            }
-            else if(sub_builder->type()->id() == arrow::Type::STRUCT) {
-                total_n_to_call_fill_on++;
-                _expected_fields_to_fill.push_back(sub_name);
-                log->error("            ====> SUB_NAME++ = {0}", sub_name);
-            }
-            log->error("{0} -        -> {1}", __PRETTYFUNCTION__, sub_name);
+            _expected_fields_filltype_map[sub_name] = helpers::column_filltype_from_builder(sub_builder, sub_name);
         }
     }
 
     for(const auto& field_to_fill : _expected_fields_to_fill) {
         _expected_field_fill_map[field_to_fill] = 0;
     }
-    log->error("{0} - TOTAL REQUIRED CALLS TO FILL PER ROW = {1}", __PRETTYFUNCTION__, total_n_to_call_fill_on);
 }
 
 void Writer::set_metadata(std::ifstream& infile) {
@@ -328,44 +296,307 @@ void Writer::set_flush_rule(const FlushRule& rule, const uint32_t& n) {
     _n_rows_in_group = n;
 }
 
+void Writer::fill_value(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer) {
+
+    if(data_buffer.size() != 1) {
+        std::stringstream err;
+        err << "Filling field \"" << field_name << "\" with expected fill type FillType::VALUE with data buffer size != 1 (size = " << data_buffer.size() << ")";
+        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::runtime_error("Invalid data buffer shape");
+    }
+
+
+    auto data = data_buffer.at(0);
+    if (auto val = std::get_if<types::buffer_value_t>(&data)) {
+        if (auto v = std::get_if<bool>(val)) {
+            helpers::fill<bool>(*v, builder);
+        } else if (auto v = std::get_if<uint8_t>(val)) {
+            helpers::fill<uint8_t>(*v, builder);
+        } else if (auto v = std::get_if<uint16_t>(val)) {
+            helpers::fill<uint16_t>(*v, builder);
+        } else if (auto v = std::get_if<uint32_t>(val)) {
+            helpers::fill<uint32_t>(*v, builder);
+        } else if (auto v = std::get_if<uint64_t>(val)) {
+            helpers::fill<uint64_t>(*v, builder);
+        } else if (auto v = std::get_if<int8_t>(val)) {
+            helpers::fill<int8_t>(*v, builder);
+        } else if (auto v = std::get_if<int16_t>(val)) {
+            helpers::fill<int16_t>(*v, builder);
+        } else if (auto v = std::get_if<int32_t>(val)) {
+            helpers::fill<int32_t>(*v, builder);
+        } else if (auto v = std::get_if<int64_t>(val)) {
+            helpers::fill<int64_t>(*v, builder);
+        } else if (auto v = std::get_if<float>(val)) {
+            helpers::fill<float>(*v, builder);
+        } else if (auto v = std::get_if<double>(val)) {
+            helpers::fill<double>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<bool>>(val)) {
+            helpers::fill<std::vector<bool>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<uint8_t>>(val)) {
+            helpers::fill<std::vector<uint8_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<uint16_t>>(val)) {
+            helpers::fill<std::vector<uint16_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<uint32_t>>(val)) {
+            helpers::fill<std::vector<uint32_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<uint64_t>>(val)) {
+            helpers::fill<std::vector<uint64_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<int8_t>>(val)) {
+            helpers::fill<std::vector<int8_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<int16_t>>(val)) {
+            helpers::fill<std::vector<int16_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<int32_t>>(val)) {
+            helpers::fill<std::vector<int32_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<int64_t>>(val)) {
+            helpers::fill<std::vector<int64_t>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<float>>(val)) {
+            helpers::fill<std::vector<float>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<double>>(val)) {
+            helpers::fill<std::vector<double>>(*v, builder);
+        } else if (auto v =
+                       std::get_if<std::vector<std::vector<bool>>>(val)) {
+            helpers::fill<std::vector<std::vector<bool>>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<std::vector<uint8_t>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<uint8_t>>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<std::vector<uint16_t>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<uint16_t>>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<std::vector<uint32_t>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<uint32_t>>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<std::vector<uint64_t>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<uint64_t>>>(*v, builder);
+        } else if (auto v =
+                       std::get_if<std::vector<std::vector<int8_t>>>(val)) {
+            helpers::fill<std::vector<std::vector<int8_t>>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<std::vector<int16_t>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<int16_t>>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<std::vector<int32_t>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<int32_t>>>(*v, builder);
+        } else if (auto v = std::get_if<std::vector<std::vector<int64_t>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<int64_t>>>(*v, builder);
+        } else if (auto v =
+                       std::get_if<std::vector<std::vector<float>>>(val)) {
+            helpers::fill<std::vector<std::vector<float>>>(*v, builder);
+        } else if (auto v =
+                       std::get_if<std::vector<std::vector<double>>>(val)) {
+            helpers::fill<std::vector<std::vector<double>>>(*v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<bool>>>>(val)) {
+            helpers::fill<std::vector<std::vector<std::vector<bool>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<uint8_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<uint8_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<uint16_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<uint16_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<uint32_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<uint32_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<uint64_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<uint64_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<int8_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<int8_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<int16_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<int16_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<int32_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<int32_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<int64_t>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<int64_t>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<float>>>>(val)) {
+            helpers::fill<std::vector<std::vector<std::vector<float>>>>(
+                *v, builder);
+        } else if (auto v = std::get_if<
+                       std::vector<std::vector<std::vector<double>>>>(
+                       val)) {
+            helpers::fill<std::vector<std::vector<std::vector<double>>>>(
+                *v, builder);
+        } else {
+            std::stringstream err;
+            err << "Invalid data type in data buffer provided for field \"" << field_name << "\"";
+            log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+            throw std::runtime_error(err.str());
+        }
+    } else {
+        std::stringstream err;
+        err << "Could not get data buffer value for filling field \"" << field_name << "\"";
+        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::runtime_error(err.str());
+    }
+
+}
+
+void Writer::fill_value_list(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer) {
+
+    if(data_buffer.size() != 1) {
+        std::stringstream err;
+        err << "Filling field \"" << field_name << "\" with expected fill type FillType::VALUE_LIST_1D with data buffer  size != 1 (size = " << data_buffer.size() << ")";
+        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::runtime_error("Invalid data buffer shape");
+    }
+
+    auto list_builder = dynamic_cast<arrow::ListBuilder*>(builder);
+    this->fill_value(field_name, list_builder, data_buffer);
+}
+
+void Writer::fill_struct_list(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer) {
+
+    auto list_builder = dynamic_cast<arrow::ListBuilder*>(builder);
+    auto [depth, terminal_builder] = helpers::list_builder_description(list_builder);
+
+    if(depth == 1) {
+        // initiate a new list element
+        PARQUET_THROW_NOT_OK(list_builder->Append());
+
+        // initiate a new struct element
+        auto value_builder = list_builder->value_builder();
+        for(size_t i = 0; i < data_buffer.size(); i++) {
+            struct_t struct_data = helpers::struct_from_data_buffer_element(data_buffer.at(i), field_name);
+            this->fill_struct(field_name, value_builder, {struct_data});
+        }
+    } else
+    if(depth == 2) {
+        PARQUET_THROW_NOT_OK(list_builder->Append());
+        list_builder = dynamic_cast<arrow::ListBuilder*>(list_builder->value_builder());
+        auto value_builder = list_builder->value_builder();
+        for(size_t i = 0; i < data_buffer.size(); i++) {
+            PARQUET_THROW_NOT_OK(list_builder->Append());
+            auto inner_data = std::get<std::vector<struct_t>>(data_buffer.at(i));
+            for(size_t j = 0; j < inner_data.size(); j++) {
+                struct_t struct_data = helpers::struct_from_data_buffer_element(inner_data.at(j), field_name);
+                this->fill_struct(field_name, value_builder, {struct_data});
+            }
+        }
+    } else
+    if(depth == 3) {
+        PARQUET_THROW_NOT_OK(list_builder->Append());
+        auto inner_list_builder = dynamic_cast<arrow::ListBuilder*>(list_builder->value_builder());
+        auto inner_inner_list_builder = dynamic_cast<arrow::ListBuilder*>(inner_list_builder->value_builder());
+        auto value_builder = inner_inner_list_builder->value_builder();
+        for(size_t i = 0; i < data_buffer.size(); i++) {
+            PARQUET_THROW_NOT_OK(inner_list_builder->Append());
+            auto inner_data = std::get<std::vector<std::vector<struct_t>>>(data_buffer.at(i));
+            for(size_t j = 0; j < inner_data.size(); j++) {
+                PARQUET_THROW_NOT_OK(inner_inner_list_builder->Append());
+                auto inner_inner_data = inner_data.at(j); //std::get<std::vector<struct_t>>(inner_data.at(j));
+                for(size_t k = 0; k < inner_inner_data.size(); k++) {
+                    struct_t struct_data = helpers::struct_from_data_buffer_element(inner_inner_data.at(k), field_name);
+                    this->fill_struct(field_name, value_builder, {struct_data});
+                } // k
+            } // j
+        } // i
+    }
+}
+
+void Writer::fill_struct(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer) {
+
+    //
+    // get the struct data
+    //
+    struct_t struct_data;
+    try {
+        struct_data = std::get<struct_t>(data_buffer.at(0));
+    } catch(std::exception& e) {
+        std::stringstream err;
+        err << "Unable to parse struct field data for field \"" << field_name << "\" (data buffer does not contain type parquetwriter::struct_t!)";
+        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::runtime_error("Invalid data buffer shape");
+    }
+
+    auto struct_builder = dynamic_cast<arrow::StructBuilder*>(builder);
+    auto [num_total_fields, num_fields_nonstruct] = helpers::field_nums_from_struct(struct_builder, field_name);
+
+    if(struct_data.size() != num_fields_nonstruct) {
+        std::stringstream err;
+        err << "Invalid number of data elements provided for struct at \"" << field_name << "\" (got: " << struct_data.size() << ", expect: " << num_fields_nonstruct << ")";
+        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::runtime_error("Invalid data buffer shape");
+    }
+
+    // initiate a new struct element
+    PARQUET_THROW_NOT_OK(struct_builder->Append());
+
+    //
+    // here will fill the fields of the struct, assuming that the order and type
+    // of the data in the provided data_buffer/struct_t matches that of the
+    // actual column type
+    //
+    auto struct_type = struct_builder->type();
+    for(size_t ifield = 0; ifield < num_total_fields; ifield++) {
+        auto field_builder = struct_builder->child_builder(ifield).get();
+        auto field_type = field_builder->type();
+        auto field_name = struct_type->field(ifield)->name();
+
+        if(ifield >= struct_data.size()) break;
+        if(field_type->id() == arrow::Type::STRUCT) {
+            ifield--;
+            continue;
+        }
+
+        std::stringstream path_name;
+        path_name << field_name << "/" << field_name;
+        this->fill_value(path_name.str(), field_builder, {struct_data.at(ifield)});
+    } // ifield
+
+}
+
+
+
 void Writer::fill(const std::string& field_path,
                   const std::vector<types::buffer_t>& data_buffer) {
 
-    log->warn("{0} - FILL CALLED FOR PATH: {1}, data_buffer.size() == {2}", __PRETTYFUNCTION__, field_path, data_buffer.size());
+
+    if(_expected_fields_filltype_map.count(field_path) == 0) {
+        std::stringstream err;
+        err << "Attempting to fill unknown field \"" << field_path << "\"";
+        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+        throw std::runtime_error(err.str());
+    }
+
+    //
+    // get the parent column name (needed for cases in which this is a sub-field)
+    //
     size_t pos_parent = field_path.find_first_of("/.");
-    // size_t pos_slash = field_path.find('/');
-    // size_t pos_dot = field_path.find_first_of("./");
-
-    // get the parent column builder for this field
-    arrow::ArrayBuilder* builder = nullptr;
-
     bool is_parent_path = false;
-    std::string parent_column_name;
-    if (pos_parent != std::string::npos) {
+    std::string parent_column_name = field_path;
+    if(pos_parent != std::string::npos) {
         parent_column_name = field_path.substr(0, pos_parent);
-    } else {
-        is_parent_path = true;
-        parent_column_name = field_path;
     }
-
-    if (_col_builder_map.count(parent_column_name) == 0) {
+    if(_column_builder_map.count(parent_column_name) == 0) {
         std::stringstream err;
-        err << "Could not find parent column with name \"" << parent_column_name
-            << "\" in loaded builders";
+        err << "Could not find parent column associated with field \"" << field_path << "\"";
         log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
         throw std::runtime_error(err.str());
     }
 
-    auto col_map = _col_builder_map.at(parent_column_name);
-    if (col_map.count(field_path) == 0) {
-        std::stringstream err;
-        err << "Cannot fill node with name \"" << field_path
-            << "\", it is not in the builder map";
-        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-        throw std::runtime_error(err.str());
-    }
-    builder = _col_builder_map.at(parent_column_name).at(field_path);
-
+    auto builder = _column_builder_map.at(parent_column_name).at(field_path);
     if(!builder) {
         std::stringstream err;
         err << "Builder for field \"" << field_path << "\" is null!";
@@ -373,767 +604,45 @@ void Writer::fill(const std::string& field_path,
         throw std::runtime_error(err.str());
     }
 
-    // auto builder = _col_builder_map.at(field_path);
-    auto builder_type = builder->type();
-    bool is_struct = builder_type->id() == arrow::Type::STRUCT;
-    bool is_list = builder_type->id() == arrow::Type::LIST;
+    //
+    // perform the fill for the corresponding supported type
+    //
+    auto field_fill_type = _expected_fields_filltype_map.at(field_path);
 
-    log->error("{0} - field_path = {1} : is_struct = {2}, is_list = {3}, type = {4}", __PRETTYFUNCTION__, field_path, is_struct, is_list, builder->type()->name());
-    for(const auto& [name, builder] : col_map) {
-        log->error("{0} - COL_MAP name = {1}", __PRETTYFUNCTION__, name);
-    }
+    if(data_buffer.size() == 0) {
 
-    if (data_buffer.size() == 0) {
-        // case of filling an empty data buffer
-        log->error("{0} - data_buffer.size() == 0");
-        this->append_empty_value(field_path);
-    }
-    //else if (data_buffer.size() > 1) {
-    else if (is_list) {
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-
-        // filling a list type
-        //
-        // filling a multivalued column field
-        //
-
-            log->error("{0} - data_buffer_size() = {1} and IS LIST LINE = {2}", __PRETTYFUNCTION__, data_buffer.size(), __LINE__);
-            // handle the case of a list of structs, which
-            // will have a data_buffer looking like:
-            // {
-            //   {a, b, {c, d}},
-            //   {a, b, {c, d}}
-            // }
-            auto list_builder = dynamic_cast<arrow::ListBuilder*>(builder);
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-            PARQUET_THROW_NOT_OK(list_builder->Append());
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-            auto value_builder = list_builder->value_builder();
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-            auto value_type = value_builder->type();
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-
-            bool is_list2 = value_type->id() == arrow::Type::LIST;
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-            if (is_list2) {
-                log->error("{0} - data_buffer_size() = {1} and IS LIST 2D", __PRETTYFUNCTION__, data_buffer.size());
-                // data_buffer looking like:
-                // {
-                //    {
-                //      {a, b, {c, d}},
-                //      {a, b, {c, d}},
-                //    }
-                // }
-
-                auto list2_builder =
-                    dynamic_cast<arrow::ListBuilder*>(value_builder);
-                if(!list2_builder) {
-                    std::stringstream err;
-                    err << "Value builder for inner list of 2D list at path \"" << field_path << "\" is null!";
-                    log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                    throw std::runtime_error(err.str());
-                }
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                PARQUET_THROW_NOT_OK(list2_builder->Append());
-
-                auto value2_builder = list2_builder->value_builder();
-                auto value2_type = value2_builder->type();
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-
-                bool is_list3 = value2_type->id() == arrow::Type::LIST;
-                if (is_list3) {
-                    log->error("{0} - data_buffer_size() = {1} and IS LIST 3D", __PRETTYFUNCTION__, data_buffer.size());
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    auto list3_builder =
-                        dynamic_cast<arrow::ListBuilder*>(value2_builder);
-                    if(!list3_builder) {
-                        std::stringstream err;
-                        err << "Value builder for inner list of 3D list at path \"" << field_path << "\" is null!";
-                        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                        throw std::runtime_error(err.str());
-                    }
-                    std::cout << "FOO list3_builder = " << list3_builder << std::endl;
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    PARQUET_THROW_NOT_OK(list3_builder->Append());
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    auto value3_builder = list3_builder->value_builder();
-                    auto value3_type = value3_builder->type();
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-
-                    std::string value_node_name = field_path + "/item/item";
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-        std::cout << "FOO filling inner inner list of 3d list at node " << value_node_name << " (field_path = " << field_path << ")" <<  std::endl;
-                    this->fill(value_node_name, {data_buffer.at(0)});
-                    //for (size_t i = 0; i < data_buffer.size(); i++) {
-        log->error("//{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    //    PARQUET_THROW_NOT_OK(list2_builder->Append());
-        log->error("//{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    //    auto ivec = std::get<std::vector<
-                    //        std::vector<std::vector<types::buffer_value_t>>>>(
-                    //        data_buffer.at(i));
-        log->error("//{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    //    for (size_t j = 0; j < ivec.size(); j++) {
-                    //        PARQUET_THROW_NOT_OK(list3_builder->Append());
-                    //        auto jvec = ivec.at(j);
-                    //        for (size_t k = 0; k < jvec.size(); k++) {
-                    //            auto element_data = jvec.at(k);
-                    //            this->fill(value_node_name, {element_data});
-                    //        }
-
-                    //    }  // j
-                    //}      // i
-
-                } else {
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    std::string value_node_name = field_path + "/item";
-                    log->error("{0} FOO {1} : value_node_name = {2}, data_buffer.size() = {3}", __PRETTYFUNCTION__, __LINE__, value_node_name, data_buffer.size());
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    //PARQUET_THROW_NOT_OK(list2_builder->Append());
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    this->fill(value_node_name, {data_buffer.at(0)});
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                    //for (size_t ielement = 0; ielement < data_buffer.size();
-                    //     ielement++) {
-                    //    PARQUET_THROW_NOT_OK(list2_builder->Append());
-                    //    this->fill(value_node_name, {data_buffer.at(ielement)});
-
-
-                    //    //auto element_data_vec = std::get<
-                    //    //    std::vector<std::vector<types::buffer_value_t>>>(
-                    //    //    data_buffer.at(ielement));
-                    //    //for (size_t jelement = 0;
-                    //    //     jelement < element_data_vec.size(); jelement++) {
-                    //    //    auto element_data = element_data_vec.at(jelement);
-
-                    //    //    this->fill(value_node_name, {element_data});
-                    //    //}  // jelement
-                    //}      // ielement
-                }          // 2d list
-            } else {
-                // if(value_type->id() != arrow::Type::STRUCT) {
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                //    std::stringstream err;
-                //    err << "ERROR: Only handle nested list[struct], but you
-                //    are trying list[" << value_type->name() << "]"; throw
-                //    std::runtime_error(err.str());
-                //}
-
-                std::string value_node_name = field_path + "/item";
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-        log->error("{0}      data_buffer.size() = {1}", __PRETTYFUNCTION__, data_buffer.size());
-                //auto element_data_vec = std::get<std::vector<types::buffer_value_t>>(data_buffer.at(0));
-                //for(size_t ielement = 0; ielement < data_buffer.size(); ielement++) {
-                //    auto element_data = std::get<std::vector<types::buffer_value_t>>(data_buffer.at(ielement))
-                //}
-        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-                this->fill(value_node_name, {data_buffer.at(0)});
-//                for (size_t ielement = 0; ielement < data_buffer.size();
-//                     ielement++) {
-//        log->error("{0}      data_buffer.size() = {1}, ielement = {2}", __PRETTYFUNCTION__, data_buffer.size(), ielement);
-//        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-//                    auto element_data_vec =
-//                        std::get<std::vector<types::buffer_value_t>>(
-//                            data_buffer.at(ielement));
-//        log->error("{0} - IS LIST LINE {1}", __PRETTYFUNCTION__, __LINE__);
-//                    this->fill(value_node_name, {element_data_vec});
-//                }  // ielement
-            }      // 1D list
-    } else if (is_struct) {
-        //} else if (auto val =
-        //               std::get_if<std::vector<types::buffer_value_t>>(&data)) {
-
-            log->error("{0} - {1} FILLING STRUCT", __PRETTYFUNCTION__, __LINE__);
-            
-            if(data_buffer.size() != 1) {
-                std::stringstream err;
-                err << "Filling struct type field with data buffer size =! 1, but size = " << data_buffer.size() << " (a data buffer of type parquetwriter::struct_t is expected!)";
-                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                throw std::runtime_error(err.str());
-            }
-
-            struct_t struct_data;
-            try {
-                struct_data = std::get<struct_t>(data_buffer.at(0));
-            } catch(std::exception& e) {
-                std::stringstream err;
-                err << "Unable to parse struct field data for field \"" << field_path << "\" (expect a data buffer of type parquetwriter::struct_t)";
-                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                throw std::runtime_error(e.what());
-            }
-
-            //types::buffer_value_vec_t field_data_vec = *val;
-            log->error("{0} - data_buffer_size() = {1},  and IS STRUCT, struct_data size = {2}", __PRETTYFUNCTION__, data_buffer.size(), struct_data.size());
-            auto struct_builder = dynamic_cast<arrow::StructBuilder*>(builder);
-
-            auto struct_type = struct_builder->type();
-            PARQUET_THROW_NOT_OK(struct_builder->Append());
-
-
-            auto [num_total_fields, num_fields_nonstruct] =
-                helpers::field_nums_from_struct(struct_builder, field_path);
-            if(struct_data.size() != num_fields_nonstruct) {
-                std::stringstream err;
-                err << " [0] Invalid number of data elements provided for "
-                       "struct column \""
-                    << field_path << "\": expect " << num_fields_nonstruct
-                    << ", got " << struct_data.size();
-                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                throw std::runtime_error(err.str());
-            }
-
-            this->fill_struct(struct_builder, struct_data, field_path);
-
-            //for (size_t ifield = 0; ifield < num_total_fields; ifield++) {
-            //    auto field_builder = struct_builder->child_builder(ifield);
-            //    auto field_type = field_builder->type();
-            //    auto field_name = struct_type->field(ifield)->name();
-
-            //    if (ifield >= struct_data.size()) break;
-            //    if (field_type->id() == arrow::Type::STRUCT) {
-            //        ifield--;
-            //        continue;
-            //    }
-
-            //    types::buffer_t field_data = struct_data.at(ifield);
-            //    if (auto val =
-            //            std::get_if<types::buffer_value_t>(&field_data)) {
-            //        std::stringstream field_node_name;
-            //        field_node_name << field_path << "." << field_name;
-            //        log->error("{0} - IS_STRUCT calling fill with field_node_name = {1}", __PRETTYFUNCTION__, field_node_name.str());
-            //        this->fill(field_node_name.str(), {*val});
-            //    }
-            //}  // ifield
-    //}      // is_struct
-    } else if (data_buffer.size() == 1) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-        auto data = data_buffer.at(0);
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-        if (auto val = std::get_if<types::buffer_value_t>(&data)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-            // data is flat (array-like)
-            if (auto v = std::get_if<bool>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<bool>(*v, builder);
-            } else if (auto v = std::get_if<uint8_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<uint8_t>(*v, builder);
-            } else if (auto v = std::get_if<uint16_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<uint16_t>(*v, builder);
-            } else if (auto v = std::get_if<uint32_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<uint32_t>(*v, builder);
-            } else if (auto v = std::get_if<uint64_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<uint64_t>(*v, builder);
-            } else if (auto v = std::get_if<int8_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<int8_t>(*v, builder);
-            } else if (auto v = std::get_if<int16_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<int16_t>(*v, builder);
-            } else if (auto v = std::get_if<int32_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<int32_t>(*v, builder);
-            } else if (auto v = std::get_if<int64_t>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<int64_t>(*v, builder);
-            } else if (auto v = std::get_if<float>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<float>(*v, builder);
-            } else if (auto v = std::get_if<double>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<double>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<bool>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<std::vector<bool>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<uint8_t>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<std::vector<uint8_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<uint16_t>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<std::vector<uint16_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<uint32_t>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<std::vector<uint32_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<uint64_t>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<std::vector<uint64_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<int8_t>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<std::vector<int8_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<int16_t>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-                helpers::fill<std::vector<int16_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<int32_t>>(val)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-        std::cout << "                  FOO builder = " << builder << std::endl;
-                helpers::fill<std::vector<int32_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<int64_t>>(val)) {
-                helpers::fill<std::vector<int64_t>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<float>>(val)) {
-                helpers::fill<std::vector<float>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<double>>(val)) {
-                helpers::fill<std::vector<double>>(*v, builder);
-            } else if (auto v =
-                           std::get_if<std::vector<std::vector<bool>>>(val)) {
-                helpers::fill<std::vector<std::vector<bool>>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<std::vector<uint8_t>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<uint8_t>>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<std::vector<uint16_t>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<uint16_t>>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<std::vector<uint32_t>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<uint32_t>>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<std::vector<uint64_t>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<uint64_t>>>(*v, builder);
-            } else if (auto v =
-                           std::get_if<std::vector<std::vector<int8_t>>>(val)) {
-                helpers::fill<std::vector<std::vector<int8_t>>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<std::vector<int16_t>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<int16_t>>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<std::vector<int32_t>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<int32_t>>>(*v, builder);
-            } else if (auto v = std::get_if<std::vector<std::vector<int64_t>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<int64_t>>>(*v, builder);
-            } else if (auto v =
-                           std::get_if<std::vector<std::vector<float>>>(val)) {
-                helpers::fill<std::vector<std::vector<float>>>(*v, builder);
-            } else if (auto v =
-                           std::get_if<std::vector<std::vector<double>>>(val)) {
-                helpers::fill<std::vector<std::vector<double>>>(*v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<bool>>>>(val)) {
-                helpers::fill<std::vector<std::vector<std::vector<bool>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<uint8_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<uint8_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<uint16_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<uint16_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<uint32_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<uint32_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<uint64_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<uint64_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<int8_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<int8_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<int16_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<int16_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<int32_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<int32_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<int64_t>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<int64_t>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<float>>>>(val)) {
-                helpers::fill<std::vector<std::vector<std::vector<float>>>>(
-                    *v, builder);
-            } else if (auto v = std::get_if<
-                           std::vector<std::vector<std::vector<double>>>>(
-                           val)) {
-                helpers::fill<std::vector<std::vector<std::vector<double>>>>(
-                    *v, builder);
-            } else {
-                std::stringstream err;
-                err << "Invalid type, cannot fill";
-                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                throw std::logic_error(err.str());
-            }
-        } else if (auto val =
-                       std::get_if<std::vector<types::buffer_value_t>>(&data)) {
-        log->error("{0} - data_buffer_size() == 1, LINE == {1}", __PRETTYFUNCTION__, __LINE__);
-            // here we handle the case of a data buffer containing a a
-            // vector of potentially differently-typed fields (e.g. a struct)
-
-            size_t try_count = 0;
-            while (builder_type->id() != arrow::Type::STRUCT) {
-                if (try_count > 3) {
-                    std::stringstream err;
-                    err << "Expected builder type of \"struct\" for field with "
-                           "name \""
-                        << field_path << "\", got \"" << builder_type->name()
-                        << "\"";
-                    log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                    throw std::runtime_error(err.str());
-                }
-                if (builder_type->id() == arrow::Type::LIST) {
-                    auto tmp = dynamic_cast<arrow::ListBuilder*>(builder)
-                                   ->value_builder();
-                    auto tmp_type = tmp->type();
-                    // if(tmp_type->id() == arrow::Type::STRUCT) {
-                    builder = tmp;
-                    builder_type = builder->type();
-                    //}
-                }
-                try_count++;
-            }
-            log->error("{0} - data_buffer_size() == 1 {1}", __PRETTYFUNCTION__, __LINE__);
-            types::buffer_value_vec_t field_data_vec = *val;
-
-            auto struct_builder = dynamic_cast<arrow::StructBuilder*>(builder);
-            auto struct_type = struct_builder->type();
-            PARQUET_THROW_NOT_OK(struct_builder->Append());
-
-            auto [num_total_fields, num_fields_nonstruct] =
-                helpers::field_nums_from_struct(struct_builder, field_path);
-            if (field_data_vec.size() != num_fields_nonstruct) {
-                std::stringstream err;
-                err << " [1] Invalid number of data elements provided for "
-                       "struct column \""
-                    << field_path << "\": expect " << num_fields_nonstruct
-                    << ", got " << field_data_vec.size();
-                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                throw std::runtime_error(err.str());
-            }
-
-            for (size_t ifield = 0; ifield < num_total_fields; ifield++) {
-                auto field_builder = struct_builder->child_builder(ifield);
-                auto field_type = field_builder->type();
-                auto field_name = struct_type->field(ifield)->ToString();
-
-                // don't consider inner structs, they must be called
-                // manually with a new call to "fill"
-
-                // for structs within structs, you MUST fill from outer to inner
-                // e.g.
-                //      writer.fill("struct", {struct_data});
-                //      writer.fill("struct.inner_struct", {inner_struct_data});
-                if (ifield >= field_data_vec.size()) break;
-                if (field_type->id() == arrow::Type::STRUCT) {
-                    ifield--;
-                    continue;
-                }
-
-                bool field_ok = false;
-                types::buffer_value_t field_data = field_data_vec.at(ifield);
-                switch (field_type->id()) {
-                    case arrow::Type::BOOL:
-                        if (auto v = std::get_if<bool>(&field_data)) {
-                            helpers::fill<bool>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT8:
-                        if (auto v = std::get_if<uint8_t>(&field_data)) {
-                            helpers::fill<uint8_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT16:
-                        if (auto v = std::get_if<uint16_t>(&field_data)) {
-                            helpers::fill<uint16_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT32:
-                        if (auto v = std::get_if<uint32_t>(&field_data)) {
-                            helpers::fill<uint32_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT64:
-                        if (auto v = std::get_if<uint64_t>(&field_data)) {
-                            helpers::fill<uint64_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT8:
-                        if (auto v = std::get_if<int8_t>(&field_data)) {
-                            helpers::fill<int8_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT16:
-                        if (auto v = std::get_if<int16_t>(&field_data)) {
-                            helpers::fill<int16_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT32:
-                        if (auto v = std::get_if<int32_t>(&field_data)) {
-                            helpers::fill<int32_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT64:
-                        if (auto v = std::get_if<int64_t>(&field_data)) {
-                            helpers::fill<int64_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::FLOAT:
-                        if (auto v = std::get_if<float>(&field_data)) {
-                            helpers::fill<float>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::DOUBLE:
-                        if (auto v = std::get_if<double>(&field_data)) {
-                            helpers::fill<double>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-
-                    case arrow::Type::LIST:
-                        if (auto v =
-                                std::get_if<std::vector<bool>>(&field_data)) {
-                            helpers::fill<std::vector<bool>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint8_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint8_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint16_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint16_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint32_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint32_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint64_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint64_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int8_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int8_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int16_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int16_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int32_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int32_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int64_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int64_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<float>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<float>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<double>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<double>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else
-                            // 2D list field
-                            if (auto v =
-                                    std::get_if<std::vector<std::vector<bool>>>(
-                                        &field_data)) {
-                            helpers::fill<std::vector<std::vector<bool>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint8_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint8_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint16_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint16_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint32_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint32_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint64_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint64_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int8_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int8_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int16_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int16_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int32_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int32_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int64_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int64_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<float>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<float>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<double>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<double>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<bool>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<bool>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint8_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<uint8_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint16_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<
-                                std::vector<std::vector<uint16_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint32_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<
-                                std::vector<std::vector<uint32_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint64_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<
-                                std::vector<std::vector<uint64_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int8_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int8_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int16_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int16_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int32_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int32_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int64_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int64_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<float>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<float>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<double>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<double>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else {
-                            std::stringstream err;
-                            err << "Unhandled fill type for struct field";
-                            log->error("{0} - {1}", __PRETTYFUNCTION__,
-                                       err.str());
-                            throw std::runtime_error(err.str());
-                        }
-                        break;
-                    default:
-                        std::stringstream err;
-                        err << "Could not field field \"" << field_name
-                            << "\" for struct \"" << field_path;
-                        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                        throw std::runtime_error(err.str());
-                        break;
-                }  // switch
-                if (!field_ok) {
-                    std::stringstream err;
-                    err << "Failed to fill field \"" << field_name
-                        << "\" for struct \"" << field_path;
-                    log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                    throw std::runtime_error(err.str());
-                }
-            }  // ifield
-        } else {
+        // the only time that an empty data buffer is valid is if this is a list type field
+        if(field_fill_type == FillType::VALUE ||
+                field_fill_type == FillType::STRUCT) {
             std::stringstream err;
-            err << "Invalid data type given to fill method for field at \""
-                << field_path << "\"";
+            err << "Empty data buffer provided for non-list field \"" << field_path << "\"";
             log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-            throw std::runtime_error(err.str());
+            throw std::runtime_error("Invalid data buffer shape");
+
         }
+        this->append_empty_value(field_path);
+    } else {
+        switch (field_fill_type) {
+            case FillType::VALUE :
+                this->fill_value(field_path, builder, data_buffer);
+                break;
+            case FillType::VALUE_LIST_1D :
+            case FillType::VALUE_LIST_2D :
+            case FillType::VALUE_LIST_3D :
+                this->fill_value_list(field_path, builder, data_buffer);
+                break;
+            case FillType::STRUCT :
+                this->fill_struct(field_path, builder, data_buffer);
+                break;
+            case FillType::STRUCT_LIST_1D :
+            case FillType::STRUCT_LIST_2D :
+            case FillType::STRUCT_LIST_3D :
+                this->fill_struct_list(field_path, builder, data_buffer);
+                break;
+            default :
+                throw std::runtime_error("Invalid FillType \"" + filltype_to_string(field_fill_type) + "\"");
+                break;
+        } // switch
     }
 
     if (std::find(_expected_fields_to_fill.begin(), _expected_fields_to_fill.end(), field_path) != _expected_fields_to_fill.end()) {
@@ -1141,364 +650,14 @@ void Writer::fill(const std::string& field_path,
         _expected_field_fill_map.at(field_path)++;
     }
 
+    // signal that the row is complete by incremented the current row length,
+    // flush if necessary
     if(row_complete()) {
-        log->error("{0} - ROW COMPLETE!", __PRETTYFUNCTION__);
         _row_length++;
         if(_row_length % _n_rows_in_group == 0) {
             this->flush();
         }
     }
-
-    //if (_field_fill_count % _expected_fields_to_fill.size() == 0) {
-
-    //    log->warn("{0} - number of fields per row filled: _field_fill_count = {1}, _expected_fields_to_fill.size() = {2}", __PRETTYFUNCTION__, _field_fill_count, _expected_fields_to_fill.size());
-
-    //    _row_length++;
-
-    //    if (_fill_count % _n_rows_in_group == 0) {
-    //        log->warn("{0} - FLUSHING _fill_count = {1}", _fill_count);
-    //        this->flush();
-    //    }
-    //}
-}
-
-void Writer::fill_struct(arrow::StructBuilder* struct_builder, struct_t struct_data, const std::string& field_path) {
-
-    log->error("{0} - FILL_STRUCT LINE = {1}", __PRETTY_FUNCTION__, __LINE__);
-            auto struct_type = struct_builder->type();
-    log->error("{0} - FILL_STRUCT LINE = {1}", __PRETTY_FUNCTION__, __LINE__);
-            PARQUET_THROW_NOT_OK(struct_builder->Append());
-    log->error("{0} - FILL_STRUCT LINE = {1}", __PRETTY_FUNCTION__, __LINE__);
-
-            auto [num_total_fields, num_fields_nonstruct] =
-                helpers::field_nums_from_struct(struct_builder, field_path);
-            if (struct_data.size() != num_fields_nonstruct) {
-                std::stringstream err;
-                err << " [1] Invalid number of data elements provided for "
-                       "struct column \""
-                    << field_path << "\": expect " << num_fields_nonstruct
-                    << ", got " << struct_data.size();
-                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                throw std::runtime_error(err.str());
-            }
-
-    log->error("{0} - FILL_STRUCT LINE = {1}", __PRETTY_FUNCTION__, __LINE__);
-            for (size_t ifield = 0; ifield < num_total_fields; ifield++) {
-    log->error("{0} - FILL_STRUCT LINE = {1}", __PRETTY_FUNCTION__, __LINE__);
-                auto field_builder = struct_builder->child_builder(ifield);
-                auto field_type = field_builder->type();
-                auto field_name = struct_type->field(ifield)->ToString();
-    log->error("{0} - FILL_STRUCT LINE = {1}", __PRETTY_FUNCTION__, __LINE__);
-
-                // don't consider inner structs, they must be called
-                // manually with a new call to "fill"
-
-                // for structs within structs, you MUST fill from outer to inner
-                // e.g.
-                //      writer.fill("struct", {struct_data});
-                //      writer.fill("struct.inner_struct", {inner_struct_data});
-                if (ifield >= struct_data.size()) break;
-                if (field_type->id() == arrow::Type::STRUCT) {
-                    ifield--;
-                    continue;
-                }
-    log->error("{0} - FILL_STRUCT LINE = {1}", __PRETTY_FUNCTION__, __LINE__);
-
-                bool field_ok = false;
-                types::buffer_value_t field_data = struct_data.at(ifield);
-                switch (field_type->id()) {
-                    case arrow::Type::BOOL:
-                        if (auto v = std::get_if<bool>(&field_data)) {
-                            helpers::fill<bool>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT8:
-                        if (auto v = std::get_if<uint8_t>(&field_data)) {
-                            helpers::fill<uint8_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT16:
-                        if (auto v = std::get_if<uint16_t>(&field_data)) {
-                            helpers::fill<uint16_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT32:
-                        if (auto v = std::get_if<uint32_t>(&field_data)) {
-                            helpers::fill<uint32_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::UINT64:
-                        if (auto v = std::get_if<uint64_t>(&field_data)) {
-                            helpers::fill<uint64_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT8:
-                        if (auto v = std::get_if<int8_t>(&field_data)) {
-                            helpers::fill<int8_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT16:
-                        if (auto v = std::get_if<int16_t>(&field_data)) {
-                            helpers::fill<int16_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT32:
-                        if (auto v = std::get_if<int32_t>(&field_data)) {
-                            helpers::fill<int32_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::INT64:
-                        if (auto v = std::get_if<int64_t>(&field_data)) {
-                            helpers::fill<int64_t>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::FLOAT:
-                        if (auto v = std::get_if<float>(&field_data)) {
-                            helpers::fill<float>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-                    case arrow::Type::DOUBLE:
-                        if (auto v = std::get_if<double>(&field_data)) {
-                            helpers::fill<double>(*v, field_builder.get());
-                            field_ok = true;
-                        }
-                        break;
-
-                    case arrow::Type::LIST:
-                        if (auto v =
-                                std::get_if<std::vector<bool>>(&field_data)) {
-                            helpers::fill<std::vector<bool>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint8_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint8_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint16_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint16_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint32_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint32_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<uint64_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<uint64_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int8_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int8_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int16_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int16_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int32_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int32_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<int64_t>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<int64_t>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<float>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<float>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<double>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<double>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else
-                            // 2D list field
-                            if (auto v =
-                                    std::get_if<std::vector<std::vector<bool>>>(
-                                        &field_data)) {
-                            helpers::fill<std::vector<std::vector<bool>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint8_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint8_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint16_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint16_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint32_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint32_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<uint64_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<uint64_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int8_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int8_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int16_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int16_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int32_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int32_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<int64_t>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<int64_t>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<float>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<float>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<
-                                       std::vector<std::vector<double>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<std::vector<double>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<bool>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<bool>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint8_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<uint8_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint16_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<
-                                std::vector<std::vector<uint16_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint32_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<
-                                std::vector<std::vector<uint32_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<uint64_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<std::vector<
-                                std::vector<std::vector<uint64_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int8_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int8_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int16_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int16_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int32_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int32_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<int64_t>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<int64_t>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<float>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<float>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else if (auto v = std::get_if<std::vector<
-                                       std::vector<std::vector<double>>>>(
-                                       &field_data)) {
-                            helpers::fill<
-                                std::vector<std::vector<std::vector<double>>>>(
-                                *v, field_builder.get());
-                            field_ok = true;
-                        } else {
-                            std::stringstream err;
-                            err << "Unhandled fill type for struct field";
-                            log->error("{0} - {1}", __PRETTYFUNCTION__,
-                                       err.str());
-                            throw std::runtime_error(err.str());
-                        }
-                        break;
-                    default:
-                        std::stringstream err;
-                        err << "Could not field field \"" << field_name
-                            << "\" for struct \"" << field_path;
-                        log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                        throw std::runtime_error(err.str());
-                        break;
-                }  // switch
-                if (!field_ok) {
-                    std::stringstream err;
-                    err << "Failed to fill field \"" << field_name
-                        << "\" for struct \"" << field_path;
-                    log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
-                    throw std::runtime_error(err.str());
-                }
-            }  // ifield
 }
 
 bool Writer::row_complete() {
@@ -1517,7 +676,7 @@ bool Writer::row_complete() {
 }
 
 void Writer::append_empty_value(const std::string& field_path) {
-    log->error("{0} - APPENDING EMPTY VALUE FOR FIELD {1}", __PRETTYFUNCTION__, field_path);
+
     arrow::ArrayBuilder* builder = nullptr;
     size_t pos_parent = field_path.find_first_of("/.");
     std::string parent_column_name = field_path;
@@ -1525,30 +684,50 @@ void Writer::append_empty_value(const std::string& field_path) {
         parent_column_name = field_path.substr(0, pos_parent);
     }
 
-    // auto col_map = _col_builder_map.at(parent_column_name);
-    builder = _col_builder_map.at(parent_column_name).at(field_path);
+    auto parent_count = _expected_field_fill_map.at(parent_column_name);
+    for(const auto [sub_field_name, sub_field_count] : _expected_field_fill_map) {
+        if(sub_field_name == parent_column_name) continue;
+        std::stringstream sub_find;
+        sub_find << parent_column_name << ".";
+        bool is_sub_field_of_parent = sub_field_name.find(sub_find.str()) != std::string::npos;
+        if(is_sub_field_of_parent) {
+            // this is a sub-field of the current parent field
+            //if(sub_field_count >= parent_count) {
+            if(sub_field_count != parent_count) {
+                std::stringstream err;
+                err << "Cannot append EMPTY VALUE to field \"" << field_path << "\", there are unequal fill counts between parent field \"" << parent_column_name << "\" and the child field \"" << field_path << "\" (parent and child fields must have \"fill\" called on them an equal number of times!)";
+                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                throw std::logic_error("Bad column filling");
+            }
+        }
+    }
+
+    builder = _column_builder_map.at(parent_column_name).at(field_path);
     auto builder_type = builder->type();
 
+    // in principle we could go through the sub-fields of the StructBuilder
+    // and ListBuilder to append null/empty to them -- however, here we just
+    // append null/empty to the parent builder which appends null/empty
+    // to all child builders. this may make the most sense so that we don't
+    // get into situations where we have to deal with the logic of
+    // offsets between parent and child fields
+ 
     // nested types (list, struct)
     bool is_struct = builder_type->id() == arrow::Type::STRUCT;
     bool is_list = builder_type->id() == arrow::Type::LIST;
     bool is_nested = is_struct || is_list;
     if (!is_nested) {
         PARQUET_THROW_NOT_OK(builder->AppendEmptyValue());
-        log->error("{0} -           => !is_nested AppendEmptyValue", __PRETTYFUNCTION__);
     } else if (is_list) {
         auto list_builder = dynamic_cast<arrow::ListBuilder*>(builder);
         PARQUET_THROW_NOT_OK(list_builder->AppendEmptyValue());
-        log->error("{0} -           => is_list AppendEmptyValue", __PRETTYFUNCTION__);
     } else if (is_struct) {
         auto struct_builder = dynamic_cast<arrow::StructBuilder*>(builder);
         PARQUET_THROW_NOT_OK(struct_builder->AppendEmptyValue());
-        log->error("{0} -           => is_struct AppendEmptyValue", __PRETTYFUNCTION__);
     }
 }
 
 void Writer::append_null_value(const std::string& field_path) {
-    log->error("{0} - APPENDING NULL VALUE FOR FIELD {1}", __PRETTYFUNCTION__, field_path);
     arrow::ArrayBuilder* builder = nullptr;
     size_t pos_parent = field_path.find_first_of("/.");
     std::string parent_column_name = field_path;
@@ -1556,8 +735,32 @@ void Writer::append_null_value(const std::string& field_path) {
         parent_column_name = field_path.substr(0, pos_parent);
     }
 
-    // auto col_map = _col_builder_map.at(parent_column_name);
-    builder = _col_builder_map.at(parent_column_name).at(field_path);
+    // if this is a sub-struct field, then assume that the parent
+    // column builder is already appending a NULL value --
+    // we should not append a null value to a sub-field since then
+    // the offsets will be incorrect (the NULL value added to the parent
+    // already adds a null to the sub-field)
+
+    auto parent_count = _expected_field_fill_map.at(parent_column_name);
+    for(const auto [sub_field_name, sub_field_count] : _expected_field_fill_map) {
+        if(sub_field_name == parent_column_name) continue;
+        std::stringstream sub_find;
+        sub_find << parent_column_name << ".";
+        bool is_sub_field_of_parent = sub_field_name.find(sub_find.str()) != std::string::npos;
+        if(is_sub_field_of_parent) {
+            // this is a sub-field of the current parent field
+            //if(sub_field_count >= parent_count) {
+            if(sub_field_count != parent_count) {
+                std::stringstream err;
+                err << "Cannot append NULL to field \"" << field_path << "\", there are unequal fill counts between parent field \"" << parent_column_name << "\" and the child field \"" << field_path << "\" (parent and child fields must have \"fill\" called on them an equal number of times!)";
+                log->error("{0} - {1}", __PRETTYFUNCTION__, err.str());
+                throw std::logic_error("Bad column filling");
+            }
+        }
+    }
+
+    // auto col_map = _column_builder_map.at(parent_column_name);
+    builder = _column_builder_map.at(parent_column_name).at(field_path);
     auto builder_type = builder->type();
 
     // nested types (list, struct)
@@ -1565,28 +768,27 @@ void Writer::append_null_value(const std::string& field_path) {
     bool is_list = builder_type->id() == arrow::Type::LIST;
     bool is_nested = is_struct || is_list;
     if (!is_nested) {
-        log->error("{0} -           => !is_nested AppendNull", __PRETTYFUNCTION__);
         PARQUET_THROW_NOT_OK(builder->AppendNull());
     } else if (is_list) {
         auto list_builder = dynamic_cast<arrow::ListBuilder*>(builder);
         PARQUET_THROW_NOT_OK(list_builder->AppendNull());
-        log->error("{0} -           => is_list AppendNull", __PRETTYFUNCTION__);
     } else if (is_struct) {
         auto struct_builder = dynamic_cast<arrow::StructBuilder*>(builder);
         PARQUET_THROW_NOT_OK(struct_builder->AppendNull());
-        log->error("{0} -           => is_struct AppendNull", __PRETTYFUNCTION__);
     }
 }
 
 void Writer::end_row() {
-    log->warn("{0} -------------------------------------", __PRETTYFUNCTION__);
     for (const auto& field : _expected_fields_to_fill) {
 
         auto field_fill_count = _expected_field_fill_map.at(field);
 
-        log->warn("{0} -   EXPECTED FIELD {1} HAS FILL COUNT = {2}", __PRETTYFUNCTION__, field, field_fill_count);
         if (field_fill_count == 0) {
+            _row_length++;
             this->append_null_value(field);
+            if(_row_length % _n_rows_in_group == 0) {
+                this->flush();
+            }
         } else if (field_fill_count > 1) {
             std::stringstream err;
             err << "Column field \"" << field << "\" has been filled "
@@ -1604,25 +806,17 @@ void Writer::end_row() {
 }
 
 void Writer::flush() {
-    log->error("{0} - IN FLUSH", __PRETTYFUNCTION__);
 
     _arrays.clear();
     std::shared_ptr<arrow::Array> array;
     for (auto& column : _columns) {
-        PARQUET_THROW_NOT_OK(_col_builder_map.at(column->name())
+        PARQUET_THROW_NOT_OK(_column_builder_map.at(column->name())
                                  .at(column->name())
                                  ->Finish(&array));
         _arrays.push_back(array);
     }
 
     auto table = arrow::Table::Make(_schema, _arrays);
-    size_t n_columns = table->num_columns();
-    log->error("{0} - LOOPING OVER TABLE COLUMNS", __PRETTYFUNCTION__);
-    for(size_t icol = 0; icol <  n_columns; icol++) {
-        auto column = table->column(icol);
-        log->error("{0} -    COLUMN \"{1}\": LENGTH = {2}", __PRETTYFUNCTION__, table->field(icol)->name(), column->length());
-
-    }
     PARQUET_THROW_NOT_OK(_file_writer->WriteTable(*table, _row_length));
     _row_length = 0;
 
@@ -1632,7 +826,6 @@ void Writer::flush() {
 }
 
 void Writer::finish() {
-    log->error("{0} - IN FINISH", __PRETTYFUNCTION__);
     this->flush();
     PARQUET_THROW_NOT_OK(_file_writer->Close());
 }

--- a/src/cpp/parquet_writer.h
+++ b/src/cpp/parquet_writer.h
@@ -70,6 +70,7 @@ class Writer {
     static const std::string flushrule2str(const FlushRule& flush_rule);
 
  private:
+
     // Parquet output wrtier
     std::unique_ptr<parquet::arrow::FileWriter> _file_writer;
     std::shared_ptr<arrow::fs::FileSystem> _fs;

--- a/src/cpp/parquet_writer.h
+++ b/src/cpp/parquet_writer.h
@@ -91,6 +91,9 @@ class Writer {
     uint32_t _fill_count;
     uint32_t _field_fill_count;
     std::map<std::string, uint64_t> _column_fill_map;
+    std::map<std::string, uint64_t> _expected_field_fill_map;
+    std::vector<std::string> _expected_fields_to_fill;
+    uint64_t _total_fills_required_per_row;
     uint32_t _row_length;
 
     Compression _compression;
@@ -100,7 +103,7 @@ class Writer {
 
     // layout of the output Parquet File
     std::shared_ptr<arrow::Schema> _schema;
-    std::vector<std::shared_ptr<arrow::Field>> _fields;
+    std::vector<std::shared_ptr<arrow::Field>> _columns;
     std::vector<std::shared_ptr<arrow::Array>> _arrays;
     nlohmann::json _file_metadata;
 
@@ -113,6 +116,9 @@ class Writer {
     //
     void update_output_stream();
     void new_file();
+
+    void fill_struct(arrow::StructBuilder* builder, struct_t data, const std::string& field_path = "");
+    bool row_complete();
 
     void flush();
 

--- a/src/cpp/parquet_writer.h
+++ b/src/cpp/parquet_writer.h
@@ -1,9 +1,9 @@
 #pragma once
 
 // parquetwriter
-#include "parquet_writer_types.h"
-#include "parquet_writer_fill_types.h"
 #include "logging.h"
+#include "parquet_writer_fill_types.h"
+#include "parquet_writer_types.h"
 namespace spdlog {
 class logger;
 }
@@ -72,7 +72,6 @@ class Writer {
     static const std::string flushrule2str(const FlushRule& flush_rule);
 
  private:
-
     // Parquet output wrtier
     std::unique_ptr<parquet::arrow::FileWriter> _file_writer;
     std::shared_ptr<arrow::fs::FileSystem> _fs;
@@ -121,10 +120,17 @@ class Writer {
     void update_output_stream();
     void new_file();
 
-    void fill_value(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
-    void fill_value_list(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
-    void fill_struct(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
-    void fill_struct_list(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
+    void fill_value(const std::string& field_name, arrow::ArrayBuilder* builder,
+                    const std::vector<types::buffer_t>& data_buffer);
+    void fill_value_list(const std::string& field_name,
+                         arrow::ArrayBuilder* builder,
+                         const std::vector<types::buffer_t>& data_buffer);
+    void fill_struct(const std::string& field_name,
+                     arrow::ArrayBuilder* builder,
+                     const std::vector<types::buffer_t>& data_buffer);
+    void fill_struct_list(const std::string& field_name,
+                          arrow::ArrayBuilder* builder,
+                          const std::vector<types::buffer_t>& data_buffer);
     bool row_complete();
 
     void flush();

--- a/src/cpp/parquet_writer.h
+++ b/src/cpp/parquet_writer.h
@@ -2,6 +2,8 @@
 
 // parquetwriter
 #include "parquet_writer_types.h"
+#include "parquet_writer_fill_types.h"
+#include "logging.h"
 namespace spdlog {
 class logger;
 }
@@ -94,6 +96,7 @@ class Writer {
     std::map<std::string, uint64_t> _column_fill_map;
     std::map<std::string, uint64_t> _expected_field_fill_map;
     std::vector<std::string> _expected_fields_to_fill;
+    std::map<std::string, FillType> _expected_fields_filltype_map;
     uint64_t _total_fills_required_per_row;
     uint32_t _row_length;
 
@@ -110,7 +113,7 @@ class Writer {
 
     // map of each column's builders
     std::map<std::string, std::map<std::string, arrow::ArrayBuilder*>>
-        _col_builder_map;
+        _column_builder_map;
 
     //
     // methods
@@ -118,7 +121,10 @@ class Writer {
     void update_output_stream();
     void new_file();
 
-    void fill_struct(arrow::StructBuilder* builder, struct_t data, const std::string& field_path = "");
+    void fill_value(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
+    void fill_value_list(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
+    void fill_struct(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
+    void fill_struct_list(const std::string& field_name, arrow::ArrayBuilder* builder, const std::vector<types::buffer_t>& data_buffer);
     bool row_complete();
 
     void flush();

--- a/src/cpp/parquet_writer_fill_types.cpp
+++ b/src/cpp/parquet_writer_fill_types.cpp
@@ -2,38 +2,38 @@
 
 namespace parquetwriter {
 
-    std::string filltype_to_string(FillType fill_type) {
-        std::string out = "INVALID";
-        switch(fill_type) {
-            case FillType::VALUE :
-                out = "VALUE";
-                break;
-            case FillType::VALUE_LIST_1D :
-                out = "VALUE_LIST_1D";
-                break;
-            case FillType::VALUE_LIST_2D :
-                out = "VAUE_LIST_2D";
-                break;
-            case FillType::VALUE_LIST_3D :
-                out = "VALUE_LIST_3D";
-                break;
-            case FillType::STRUCT :
-                out = "STRUCT";
-                break;
-            case FillType::STRUCT_LIST_1D :
-                out = "STRUCT_LIST_1D";
-                break;
-            case FillType::STRUCT_LIST_2D :
-                out = "STRUCT_LIST_2D";
-                break;
-            case FillType::STRUCT_LIST_3D :
-                out = "STRUCT_LIST_3D";
-                break;
-            default :
-                out = "INVALID";
-                break;
-        } // switch
-        return out;
-    }
+std::string filltype_to_string(FillType fill_type) {
+    std::string out = "INVALID";
+    switch (fill_type) {
+        case FillType::VALUE:
+            out = "VALUE";
+            break;
+        case FillType::VALUE_LIST_1D:
+            out = "VALUE_LIST_1D";
+            break;
+        case FillType::VALUE_LIST_2D:
+            out = "VAUE_LIST_2D";
+            break;
+        case FillType::VALUE_LIST_3D:
+            out = "VALUE_LIST_3D";
+            break;
+        case FillType::STRUCT:
+            out = "STRUCT";
+            break;
+        case FillType::STRUCT_LIST_1D:
+            out = "STRUCT_LIST_1D";
+            break;
+        case FillType::STRUCT_LIST_2D:
+            out = "STRUCT_LIST_2D";
+            break;
+        case FillType::STRUCT_LIST_3D:
+            out = "STRUCT_LIST_3D";
+            break;
+        default:
+            out = "INVALID";
+            break;
+    }  // switch
+    return out;
+}
 
-}; // namespace parquetwriter
+};  // namespace parquetwriter

--- a/src/cpp/parquet_writer_fill_types.cpp
+++ b/src/cpp/parquet_writer_fill_types.cpp
@@ -1,0 +1,39 @@
+#include "parquet_writer_fill_types.h"
+
+namespace parquetwriter {
+
+    std::string filltype_to_string(FillType fill_type) {
+        std::string out = "INVALID";
+        switch(fill_type) {
+            case FillType::VALUE :
+                out = "VALUE";
+                break;
+            case FillType::VALUE_LIST_1D :
+                out = "VALUE_LIST_1D";
+                break;
+            case FillType::VALUE_LIST_2D :
+                out = "VAUE_LIST_2D";
+                break;
+            case FillType::VALUE_LIST_3D :
+                out = "VALUE_LIST_3D";
+                break;
+            case FillType::STRUCT :
+                out = "STRUCT";
+                break;
+            case FillType::STRUCT_LIST_1D :
+                out = "STRUCT_LIST_1D";
+                break;
+            case FillType::STRUCT_LIST_2D :
+                out = "STRUCT_LIST_2D";
+                break;
+            case FillType::STRUCT_LIST_3D :
+                out = "STRUCT_LIST_3D";
+                break;
+            default :
+                out = "INVALID";
+                break;
+        } // switch
+        return out;
+    }
+
+}; // namespace parquetwriter

--- a/src/cpp/parquet_writer_fill_types.h
+++ b/src/cpp/parquet_writer_fill_types.h
@@ -5,21 +5,21 @@
 
 namespace parquetwriter {
 
-    // supported types for a given column in the
-    // output Parquet files
-    enum class FillType {
-        VALUE
-        ,VALUE_LIST_1D
-        ,VALUE_LIST_2D
-        ,VALUE_LIST_3D
-        ,STRUCT
-        ,STRUCT_LIST_1D
-        ,STRUCT_LIST_2D
-        ,STRUCT_LIST_3D
-        ,INVALID
-    }; // enum FillTypes
+// supported types for a given column in the
+// output Parquet files
+enum class FillType {
+    VALUE,
+    VALUE_LIST_1D,
+    VALUE_LIST_2D,
+    VALUE_LIST_3D,
+    STRUCT,
+    STRUCT_LIST_1D,
+    STRUCT_LIST_2D,
+    STRUCT_LIST_3D,
+    INVALID
+};  // enum FillTypes
 
-    std::string filltype_to_string(FillType fill_type);
-}; // namespace parquetwriter
+std::string filltype_to_string(FillType fill_type);
+};  // namespace parquetwriter
 
 #endif

--- a/src/cpp/parquet_writer_fill_types.h
+++ b/src/cpp/parquet_writer_fill_types.h
@@ -1,6 +1,8 @@
 #ifndef PARQUETWRITER_FILL_TYPES_H
 #define PARQUETWRITER_FILL_TYPES_H
 
+#include <string>
+
 namespace parquetwriter {
 
     // supported types for a given column in the
@@ -17,6 +19,7 @@ namespace parquetwriter {
         ,INVALID
     }; // enum FillTypes
 
+    std::string filltype_to_string(FillType fill_type);
 }; // namespace parquetwriter
 
 #endif

--- a/src/cpp/parquet_writer_fill_types.h
+++ b/src/cpp/parquet_writer_fill_types.h
@@ -1,0 +1,22 @@
+#ifndef PARQUETWRITER_FILL_TYPES_H
+#define PARQUETWRITER_FILL_TYPES_H
+
+namespace parquetwriter {
+
+    // supported types for a given column in the
+    // output Parquet files
+    enum class FillType {
+        VALUE
+        ,VALUE_LIST_1D
+        ,VALUE_LIST_2D
+        ,VALUE_LIST_3D
+        ,STRUCT
+        ,STRUCT_LIST_1D
+        ,STRUCT_LIST_2D
+        ,STRUCT_LIST_3D
+        ,INVALID
+    }; // enum FillTypes
+
+}; // namespace parquetwriter
+
+#endif

--- a/src/cpp/tools/CMakeLists.txt
+++ b/src/cpp/tools/CMakeLists.txt
@@ -4,3 +4,7 @@
 ##
 add_executable(test-writer test_writer.cpp)
 target_link_libraries(test-writer PRIVATE parquet-writer)
+add_executable(test-layout test_layout.cpp)
+target_link_libraries(test-layout PRIVATE parquet-writer)
+add_executable(test-value test_value.cpp)
+target_link_libraries(test-value PRIVATE parquet-writer)


### PR DESCRIPTION
This PR refactors all of the filling methods.

It also adds a new `FillType` enum to define explicitly the few data types that are supported by
a given field layout provided to `parquetwriter::Writer`.

This MR also constrains the supported data types so that `list`-type columns (`list[value_type]`, or `list[struct]`) cannot
have terminal value struct fields that are themselves of `struct`-type. Of course, a column of `struct` type can have as many `list[struct]` fields it wishes to have -- just that the "sub-struct" depth is always 1. This is to simplify things. Also, I think any complex data structure can be created with this "sub-struct" depth of 1.