### PR TITLE
feat: struct map

### DIFF
--- a/examples/cpp/struct_example.cpp
+++ b/examples/cpp/struct_example.cpp
@@ -67,18 +67,7 @@ int main(int argc, char* argv[]) {
                                             {"name": "list_field", "type": "list1d",
                                                         "contains": {"type": "int32"}}
                                         ]}}
-                        ]},
-            {"name": "struct_with_struct_list2d", "type": "struct",
-                "fields":[
-                    {"name": "float_field", "type": "float"},
-                    {"name": "struct_list", "type": "list2d",
-                        "contains": {"type": "struct", "fields":[
-                                        {"name": "float_field", "type": "float"},
-                                        {"name": "int_field", "type": "int32"},
-                                        {"name": "list_field", "type": "list1d",
-                                                "contains": {"type": "int32"}}
-                                    ]}}]
-                }
+                        ]}
         ]
     }
     )"_json;
@@ -124,59 +113,43 @@ int main(int argc, char* argv[]) {
 
     // the "basic_struct" column holds a single struct element in each row (it
     // is flat)
-    pw::field_map_t basic_struct_data{ {"float_field", float_field_data},
-                                       {"int_field", int_field_data},
-                                       {"list_field", list_field_data} };
-    //pw::struct_t basic_struct_data{float_field_data, int_field_data,
-    //                               list_field_data};
+    std::map<std::string, pw::value_t> basic_struct_data{
+        {"float_field", float_field_data},
+        {"int_field", int_field_data},
+        {"list_field", list_field_data}
+
+    };
 
     // the "struct_list1d" column holds a list of struct elements in each row
     // (here the list length is arbitrarily set to 7)
-    pw::struct_list1d struct_list_data;
+    std::vector<std::map<std::string, pw::value_t>> struct_list_data;
     for (size_t i = 0; i < 7; i++) {
-        pw::field_map_t struct_map{ {"float_field", float_field_data},
-                                    {"int_field", int_field_data},
-                                    {"list_field", list_field_data} };
-        pw::struct_t struct_data = writer.to_struct("struct_list1d", struct_map);
+        std::map<std::string, pw::value_t> struct_data{
+            {"float_field", float_field_data},
+            {"int_field", int_field_data},
+            {"list_field", list_field_data}};
         struct_list_data.push_back(struct_data);
     }  // i
-
-    pw::struct_t float_field{float_field_data};
-    pw::struct_list2d struct_list2d_data;
-    for (size_t i = 0; i < 5; i++) {
-        std::vector<pw::struct_t> inner_data;
-        for (size_t j = 0; j < 2; j++) {
-            pw::struct_t data{float_field_data, int_field_data,
-                              list_field_data};
-            inner_data.push_back(data);
-        }
-        struct_list2d_data.push_back(inner_data);
-    }
 
     //
     // fill a couple of rows with the same set of dummy data in each
     //
     for (size_t irow = 0; irow < 10; irow++) {
         // basic_struct
-        writer.fill("basic_struct", {basic_struct_data});
+        writer.fill_struct("basic_struct", {basic_struct_data});
 
         // one-dimensional list of structs
-        writer.fill("struct_list1d", {struct_list_data});
-
-        writer.fill("struct_with_struct_list2d", {float_field});
-        writer.fill("struct_with_struct_list2d.struct_list",
-                    {struct_list2d_data});
+        writer.fill_struct_list1d("struct_list1d", {struct_list_data});
 
         // struct with struct field
-        writer.fill("struct_with_struct", {basic_struct_data});
-        writer.fill("struct_with_struct.struct_field", {basic_struct_data});
+        writer.fill_struct("struct_with_struct", {basic_struct_data});
+        writer.fill_struct("struct_with_struct.struct_field",
+                           {basic_struct_data});
 
         // struct with a field that is a list of structs
-        // note #1: the outer struct must always have fields to be filled if the
-        // inner struct is to be filled note #2: fill the internal structs'
-        // fields independently of the outer structs' fields
-        writer.fill("struct_with_struct_list", {basic_struct_data});
-        writer.fill("struct_with_struct_list.struct_list", {struct_list_data});
+        writer.fill_struct("struct_with_struct_list", {basic_struct_data});
+        writer.fill_struct_list1d("struct_with_struct_list.struct_list",
+                                  {struct_list_data});
 
         // finish handling the current row
         writer.end_row();

--- a/examples/cpp/struct_example.cpp
+++ b/examples/cpp/struct_example.cpp
@@ -124,15 +124,20 @@ int main(int argc, char* argv[]) {
 
     // the "basic_struct" column holds a single struct element in each row (it
     // is flat)
-    pw::struct_t basic_struct_data{float_field_data, int_field_data,
-                                   list_field_data};
+    pw::field_map_t basic_struct_data{ {"float_field", float_field_data},
+                                       {"int_field", int_field_data},
+                                       {"list_field", list_field_data} };
+    //pw::struct_t basic_struct_data{float_field_data, int_field_data,
+    //                               list_field_data};
 
     // the "struct_list1d" column holds a list of struct elements in each row
     // (here the list length is arbitrarily set to 7)
     pw::struct_list1d struct_list_data;
     for (size_t i = 0; i < 7; i++) {
-        pw::struct_t struct_data{float_field_data, int_field_data,
-                                 list_field_data};
+        pw::field_map_t struct_map{ {"float_field", float_field_data},
+                                    {"int_field", int_field_data},
+                                    {"list_field", list_field_data} };
+        pw::struct_t struct_data = writer.to_struct("struct_list1d", struct_map);
         struct_list_data.push_back(struct_data);
     }  // i
 

--- a/src/cpp/parquet_writer.h
+++ b/src/cpp/parquet_writer.h
@@ -59,6 +59,8 @@ class Writer {
 
     void fill(const std::string& field_path,
               const std::vector<types::buffer_t>& data_buffer);
+    void fill(const std::string& field_path,
+              const std::vector<field_map_t>& struct_field_map);
 
     void append_empty_value(const std::string& field_path);
     void append_null_value(const std::string& field_path);
@@ -118,6 +120,7 @@ class Writer {
     void update_output_stream();
     void new_file();
 
+    std::vector<std::string> struct_fill_order(const std::string& field_path);
     void fill_value(const std::string& field_name, arrow::ArrayBuilder* builder,
                     const std::vector<types::buffer_t>& data_buffer);
     void fill_value_list(const std::string& field_name,

--- a/src/cpp/parquet_writer.h
+++ b/src/cpp/parquet_writer.h
@@ -57,12 +57,26 @@ class Writer {
     void set_flush_rule(const FlushRule& rule, const uint32_t& n);
     void set_pagesize(const uint32_t& pagesize) { _data_pagesize = pagesize; }
 
-    struct_t to_struct(const std::string& field_path, const field_map_t& struct_field_map);
+    field_buffer_t to_struct(const std::string& field_path,
+                             const field_map_t& struct_field_map);
 
     void fill(const std::string& field_path,
               const std::vector<types::buffer_t>& data_buffer);
-    void fill(const std::string& field_path,
-              const std::vector<field_map_t>& struct_field_map);
+
+    void fill_struct(const std::string& field_path,
+                     const std::map<std::string, value_t>& struct_buffer);
+    void fill_struct_list1d(
+        const std::string& field_path,
+        const std::vector<std::map<std::string, value_t>>& struct_buffer);
+    void fill_struct_list2d(
+        const std::string& field_path,
+        const std::vector<std::vector<std::map<std::string, value_t>>>&
+            struct_buffer);
+    void fill_struct_list3d(
+        const std::string& field_path,
+        const std::vector<
+            std::vector<std::vector<std::map<std::string, value_t>>>>&
+            struct_buffer);
 
     void append_empty_value(const std::string& field_path);
     void append_null_value(const std::string& field_path);
@@ -128,12 +142,12 @@ class Writer {
     void fill_value_list(const std::string& field_name,
                          arrow::ArrayBuilder* builder,
                          const std::vector<types::buffer_t>& data_buffer);
-    void fill_struct(const std::string& field_name,
-                     arrow::ArrayBuilder* builder,
-                     const std::vector<types::buffer_t>& data_buffer);
-    void fill_struct_list(const std::string& field_name,
-                          arrow::ArrayBuilder* builder,
-                          const std::vector<types::buffer_t>& data_buffer);
+    void fill_struct_(const std::string& field_name,
+                      arrow::ArrayBuilder* builder,
+                      const std::vector<types::buffer_t>& data_buffer);
+    void fill_struct_list_(const std::string& field_name,
+                           arrow::ArrayBuilder* builder,
+                           const std::vector<types::buffer_t>& data_buffer);
 
     void increment_field_fill_count(const std::string& field_path);
     void check_row_complete();

--- a/src/cpp/parquet_writer.h
+++ b/src/cpp/parquet_writer.h
@@ -57,6 +57,8 @@ class Writer {
     void set_flush_rule(const FlushRule& rule, const uint32_t& n);
     void set_pagesize(const uint32_t& pagesize) { _data_pagesize = pagesize; }
 
+    struct_t to_struct(const std::string& field_path, const field_map_t& struct_field_map);
+
     void fill(const std::string& field_path,
               const std::vector<types::buffer_t>& data_buffer);
     void fill(const std::string& field_path,

--- a/src/cpp/parquet_writer_helpers.cpp
+++ b/src/cpp/parquet_writer_helpers.cpp
@@ -4,6 +4,7 @@
 
 // std/stl
 #include <sstream>
+
 namespace parquetwriter {
 namespace helpers {
 

--- a/src/cpp/parquet_writer_helpers.h
+++ b/src/cpp/parquet_writer_helpers.h
@@ -80,6 +80,9 @@ parquetwriter::FillType column_filltype_from_builder(
 
 bool valid_sub_struct_layout(arrow::StructBuilder* struct_builder,
                              const std::string& parent_column_name);
+std::vector<std::string> struct_field_order_from_builder(
+    arrow::ArrayBuilder* builder, const std::string& field_path);
+bool builder_is_struct_type(arrow::ArrayBuilder* builder);
 std::pair<unsigned, arrow::ArrayBuilder*> list_builder_description(
     arrow::ListBuilder* list_builder);
 std::pair<std::vector<std::string>, std::vector<arrow::ArrayBuilder*>>

--- a/src/cpp/parquet_writer_helpers.h
+++ b/src/cpp/parquet_writer_helpers.h
@@ -89,7 +89,7 @@ std::pair<std::vector<std::string>, std::vector<arrow::ArrayBuilder*>>
 struct_type_field_builders(arrow::ArrayBuilder* builder,
                            const std::string& column_name);
 
-parquetwriter::struct_t struct_from_data_buffer_element(
+parquetwriter::field_buffer_t struct_from_data_buffer_element(
     const parquetwriter::types::buffer_t& data, const std::string& field_name);
 
 std::pair<unsigned, unsigned> field_nums_from_struct(

--- a/src/cpp/parquet_writer_types.h
+++ b/src/cpp/parquet_writer_types.h
@@ -71,6 +71,7 @@ typedef std::variant<buffer_value_t, buffer_value_vec_t, buffer_value_vec2d_t,
 typedef std::vector<types::buffer_t> struct_list3d;
 typedef std::vector<types::buffer_t> struct_list2d;
 typedef std::vector<types::buffer_t> struct_list1d;
-typedef types::buffer_value_vec_t struct_t;
+typedef types::buffer_value_vec_t field_buffer_t;
+typedef types::buffer_value_t value_t;
 typedef std::map<std::string, types::buffer_value_t> field_map_t;
 };  // namespace parquetwriter

--- a/src/cpp/parquet_writer_types.h
+++ b/src/cpp/parquet_writer_types.h
@@ -3,6 +3,7 @@
 // std/stl
 #include <stdint.h>
 
+#include <map>
 #include <variant>
 #include <vector>
 
@@ -71,4 +72,5 @@ typedef std::vector<types::buffer_t> struct_list3d;
 typedef std::vector<types::buffer_t> struct_list2d;
 typedef std::vector<types::buffer_t> struct_list1d;
 typedef types::buffer_value_vec_t struct_t;
+typedef std::map<std::string, types::buffer_value_t> field_map_t;
 };  // namespace parquetwriter

--- a/src/cpp/tools/test_writer.cpp
+++ b/src/cpp/tools/test_writer.cpp
@@ -110,11 +110,11 @@ int main(int argc, char* argv[]) {
     // col13
     uint32_t col13_field_foo = 42;
     double col13_field_bar = 103.7;
-    pw::struct_t col13_data{col13_field_foo, col13_field_bar};
+    pw::field_buffer_t col13_data{col13_field_foo, col13_field_bar};
     // col14
     pw::struct_list1d col14_data;
     for (size_t i = 0; i < 5; i++) {
-        pw::struct_t col14_element_field_data;
+        pw::field_buffer_t col14_element_field_data;
         uint32_t col14_field_faz = 32;
         std::vector<int32_t> col14_field_baz{1, -2, 3, -4};
         col14_element_field_data.push_back(col14_field_faz);
@@ -135,9 +135,9 @@ int main(int argc, char* argv[]) {
     // col18
     pw::struct_list2d col18_data;
     for (size_t i = 0; i < 3; i++) {
-        std::vector<pw::struct_t> inner_data;
+        std::vector<pw::field_buffer_t> inner_data;
         for (size_t j = 0; j < (i + 1); j++) {
-            pw::struct_t col18_element_field_data;
+            pw::field_buffer_t col18_element_field_data;
             float col18_field_foo = i * j;
             int32_t col18_field_bar = i * j + 2;
             col18_element_field_data.push_back(col18_field_foo);
@@ -150,11 +150,11 @@ int main(int argc, char* argv[]) {
     // col19
     pw::struct_list3d col19_data;
     for (size_t i = 0; i < 5; i++) {
-        std::vector<std::vector<pw::struct_t>> inner3_data;
+        std::vector<std::vector<pw::field_buffer_t>> inner3_data;
         for (size_t j = 0; j < 3; j++) {
-            std::vector<pw::struct_t> inner2_data;
+            std::vector<pw::field_buffer_t> inner2_data;
             for (size_t k = 0; k < 2; k++) {
-                pw::struct_t col19_element_field_data;
+                pw::field_buffer_t col19_element_field_data;
                 float col19_field_foo = i * j * k;
                 int32_t col19_field_bar = i * j * k + 2;
                 col19_element_field_data.push_back(col19_field_foo);


### PR DESCRIPTION
Create `fill_struct`, `fill_struct_list1d`, `fill_struct_list2d`, and `fill_struct_list3d` methods.

Use `std::map<std::string, pw::value_t>` for filling `struct`-type columns/fields.